### PR TITLE
Dates in URLs and document meta data

### DIFF
--- a/grow/pods/collectionz/documents.py
+++ b/grow/pods/collectionz/documents.py
@@ -180,6 +180,18 @@ class Document(object):
       root_path = root_path[0:len(root_path)-1]
     path_format = root_path + path_format
 
+    # Handle default date formatting in the url.
+    while '{date|' in path_format:
+      re_date = r'({date\|(?P<date_format>[a-zA-Z0-9_%-]+)})'
+      match = re.search(re_date, path_format)
+      if match:
+        formatted_date = self.date
+        formatted_date = formatted_date.strftime(match.group('date_format'))
+        path_format = path_format[:match.start()] + formatted_date + path_format[match.end():]
+      else:
+        # Does not match expected format, let the normal format attempt it.
+        break;
+
     # Handle the special formatting of dates in the url.
     while '{dates.' in path_format:
       re_dates = r'({dates\.(?P<date_name>\w+)(\|(?P<date_format>[a-zA-Z0-9_%-]+))?})'
@@ -200,6 +212,7 @@ class Document(object):
           'podspec': self.pod.get_podspec(),
           'base': os.path.splitext(os.path.basename(self.pod_path))[0],
           'slug': self.slug,
+          'date': self.date,
       }).replace('//', '/')
     except KeyError:
       logging.error('Error with path format: {}'.format(path_format))


### PR DESCRIPTION
Updating the dates to follow the [discussed format](https://groups.google.com/forum/#!topic/growsdk/GBVe6CTTfrE) and to act like titles in the document front-matter.

At the same time the serving path logic has been updated to detect usage of the `dates.date_name` format and format the date accordingly.

Also removing the `published` since it is old school.
