### PR TITLE
Start of Python 3 Support

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -1,5 +1,11 @@
 from grow.pods import errors
-import cStringIO
+try:
+    import cStringIO as StringIO
+except ImportError:
+    try:
+        import StringIO
+    except ImportError:
+        from io import StringIO
 import csv as csv_lib
 import functools
 import gettext
@@ -189,7 +195,7 @@ def load_yaml(*args, **kwargs):
 
 def load_yaml_all(*args, **kwargs):
     pod = kwargs.pop('pod', None)
-    fp = cStringIO.StringIO()
+    fp = StringIO.StringIO()
     fp.write(args[0])
     fp.seek(0)
     loader = make_yaml_loader(pod)

--- a/grow/pods/storage/gettext_storage.py
+++ b/grow/pods/storage/gettext_storage.py
@@ -45,7 +45,7 @@ internationalized, to the local language and cultural habits.
 # - Support Solaris .mo file formats.  Unfortunately, we've been unable to
 #   find this format documented anywhere.
 
-
+import six
 import locale, copy, os, re, struct, sys
 from errno import ENOENT
 
@@ -89,11 +89,11 @@ def c2py(plural):
     try:
         danger = [x for x in tokens if x[0] == token.NAME and x[1] != 'n']
     except tokenize.TokenError:
-        raise ValueError, \
-              'plural forms expression error, maybe unbalanced parenthesis'
+        raise ValueError(
+              'plural forms expression error, maybe unbalanced parenthesis')
     else:
         if danger:
-            raise ValueError, 'plural forms expression could be dangerous'
+            raise ValueError('plural forms expression could be dangerous')
 
     # Replace some C operators by their Python equivalents
     plural = plural.replace('&&', ' and ')
@@ -119,7 +119,7 @@ def c2py(plural):
                 # Actually, we never reach this code, because unbalanced
                 # parentheses get caught in the security check at the
                 # beginning.
-                raise ValueError, 'unbalanced parenthesis in plural form'
+                raise ValueError('unbalanced parenthesis in plural form')
             s = expr.sub(repl, stack.pop())
             stack[-1] += '(%s)' % s
         else:
@@ -259,8 +259,12 @@ class NullTranslations:
 
 class GNUTranslations(NullTranslations):
     # Magic number of .mo files
-    LE_MAGIC = 0x950412deL
-    BE_MAGIC = 0xde120495L
+    if six.PY2:
+        LE_MAGIC = long(0x950412de)
+        BE_MAGIC = long(0xde120495)
+    else:
+        LE_MAGIC = 0x950412de
+        BE_MAGIC = 0xde120495
 
     def _parse(self, fp):
         """Override this method to support alternative .mo formats."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,11 @@ Twisted==16.0.0
 WebOb==1.3.1
 Werkzeug==0.9.4
 beautifulsoup4==4.4.0
-boto==2.29.1
+boto==2.40.0
 certifi==1.0.0
 click==4.0
 coverage==3.7.1
-dulwich==0.9.6
+dulwich==0.13.0
 ez-setup==0.9
 gcs-oauth2-boto-plugin==1.9
 goslate==1.4.0


### PR DESCRIPTION
Replaces #207, and merges into `develop` instead.

I'd like to continue more Py3 support, but kept running into package compatibilities. Mostly around all the GAE stuff. So your call if you want one giant PR with all the Py3 stuff in it, or ok with smaller PRs to incrementally bring support up.

Some PRs created in the process of bringing Py3 support up on the dependencies are:
- https://github.com/GoogleCloudPlatform/appengine-gcs-client/pull/33
- https://github.com/jeremydw/protorpc-standalone/pull/1
- https://github.com/GoogleCloudPlatform/webapp2/pull/110