### PR TITLE
Refactor `Catalogs.extract()` to implement more consistent behaviour

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -191,16 +191,7 @@ def load_yaml(*args, **kwargs):
     pod = kwargs.pop('pod', None)
     doc = kwargs.pop('doc', None)
     loader = make_yaml_loader(pod, doc=doc)
-    return yaml.load(*args, Loader=loader, **kwargs)
-
-
-def load_yaml_all(*args, **kwargs):
-    pod = kwargs.pop('pod', None)
-    fp = StringIO.StringIO()
-    fp.write(args[0])
-    fp.seek(0)
-    loader = make_yaml_loader(pod)
-    return yaml.load_all(*args, Loader=loader, **kwargs)
+    return yaml.load(*args, Loader=loader, **kwargs) or {}
 
 
 @memoize

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -280,7 +280,7 @@ def get_rows_from_csv(pod, path, locale=SENTINEL):
 
 
 def import_string(import_name, paths):
-    """ Imports & returns an object using dot notation, e.g. 'A.B.C' """
+    """Imports & returns an object using dot notation, e.g. 'A.B.C'"""
     # ASSUMPTION: import_name refers to a value in a module (i.e. must have at
     # least 2 parts)
     if '.' not in import_name:

--- a/grow/pods/catalog_holder.py
+++ b/grow/pods/catalog_holder.py
@@ -235,7 +235,7 @@ class Catalogs(object):
 
         # Extract from root of /content/:
         for path in self.pod.list_dir('/content/', recursive=False):
-            if path.endswith('.yaml') or path.endswith('.yml'):
+            if path.endswith(('.yaml', '.yml')):
                 pod_path = os.path.join('/content/', path)
                 self.pod.logger.info('Extracting: {}'.format(pod_path))
                 utils.walk(

--- a/grow/pods/catalog_holder.py
+++ b/grow/pods/catalog_holder.py
@@ -189,9 +189,18 @@ class Catalogs(object):
         # Extract from collections in /content/:
         # Strings only extracted for relevant locales, determined by locale
         # scope (pod > collection > document > document part)
+        last_pod_path = None
         for collection in self.pod.list_collections():
             for doc in collection.list_docs(include_hidden=True):
-                self.pod.logger.info('Extracting: {}'.format(doc.pod_path))
+                if doc.pod_path != last_pod_path:
+                    self.pod.logger.info(
+                        'Extracting: {} ({} locale{})'.format(
+                            doc.pod_path,
+                            len(doc.locales),
+                            's' if len(doc.locales) > 1 else '',
+                        )
+                    )
+                    last_pod_path = doc.pod_path
 
                 # If doc.locale is set, this is a doc part: only extract for
                 # its own locales (not those of base doc).

--- a/grow/pods/catalog_holder.py
+++ b/grow/pods/catalog_holder.py
@@ -231,7 +231,7 @@ class Catalogs(object):
                     rows = self.pod.read_csv(pod_path)
                     for i, row in enumerate(rows):
                         for key, msgid in row.iteritems():
-                            _handle_field(pod_path, collection.list_locales(), msgid, key, row)
+                            _handle_field(pod_path, collection.locales, msgid, key, row)
 
         # Extract from root of /content/:
         for path in self.pod.list_dir('/content/', recursive=False):

--- a/grow/pods/catalog_holder.py
+++ b/grow/pods/catalog_holder.py
@@ -10,6 +10,7 @@ from grow.pods import messages
 import click
 import collections
 import os
+import StringIO
 import tokenize
 
 
@@ -111,42 +112,18 @@ class Catalogs(object):
         if content:
             importer.import_content(content=content, locale=locale)
 
-    def _get_or_create_catalog(self, template_path):
-        exists = True
-        if not self.pod.file_exists(template_path):
-            self.pod.create_file(template_path, None)
-            exists = False
-        catalog = pofile.read_po(self.pod.open_file(template_path))
-        return catalog, exists
-
-    def _add_message(self, catalog, message):
-        lineno, string, comments, context = message
-        flags = set()
-        if string in catalog:
-            existing_message = catalog.get(string)
-            flags = existing_message.flags
-        return catalog.add(string, None, auto_comments=comments, context=context,
-                           flags=flags)
-
-    def _should_extract_as_csv(self, given_paths, path):
-        ext = os.path.splitext(path)[-1]
-        if ext != '.csv':
-            return False
-        return given_paths is None or path in given_paths
-
-    def _should_extract_as_babel(self, given_paths, path):
-        if os.path.splitext(path)[-1] not in _TRANSLATABLE_EXTENSIONS:
-            return False
-        return not given_paths or path in given_paths
-
     def extract(self, include_obsolete=False, localized=False, paths=None,
                 include_header=False, locales=None, use_fuzzy_matching=False):
         env = self.pod.create_template_env()
 
-        all_locales = set(list(self.pod.list_locales()))
-        message_ids_to_messages = {}
-        paths_to_messages = collections.defaultdict(set)
-        paths_to_locales = collections.defaultdict(set)
+        # {
+        #    locale1: locale1_catalog,
+        #    locale2: locale2_catalog,
+        #    ...
+        # }
+        # This is built up as we extract
+        localized_catalogs = {}
+        unlocalized_catalog = catalogs.Catalog()  # for localized=False case
 
         comment_tags = [
             ':',
@@ -156,37 +133,24 @@ class Catalogs(object):
             'silent': 'false',
         }
 
-        # Extract from content files.
-        def callback(doc, item, key, unused_node):
-            # Verify that the fields we're extracting are fields for a document
-            # that's in the default locale. If not, skip the document.
-            _handle_field(doc.pod_path, item, key, unused_node)
+        def _add_to_catalog(message, locales):
+            # Add to all relevant catalogs
+            for locale in locales:
+                if locale not in localized_catalogs:
+                    # Start with a new catalog so we can track what's obsolete:
+                    # we'll merge it with existing translations later.
+                    # *NOT* setting `locale` kwarg here b/c that will load existing
+                    # translations.
+                    localized_catalogs[locale] = catalogs.Catalog(pod=self.pod)
+                localized_catalogs[locale][message.id] = message
+            unlocalized_catalog[message.id] = message
 
-        def _add_existing_message(msgid, locations, auto_comments=None,
-                                  context=None, path=None):
-            existing_message = message_ids_to_messages.get(msgid)
-            auto_comments = [] if auto_comments is None else auto_comments
-            if existing_message:
-                message_ids_to_messages[msgid].locations.extend(locations)
-                paths_to_messages[path].add(existing_message)
-            else:
-                message = catalog.Message(
-                    msgid,
-                    None,
-                    auto_comments=auto_comments,
-                    context=context,
-                    locations=locations)
-                paths_to_messages[path].add(message)
-                message_ids_to_messages[message.id] = message
-
-        def _handle_field(path, item, key, node):
+        def _handle_field(path, locales, msgid, key, node):
             if (not key
                     or not key.endswith('@')
-                    or not isinstance(item, basestring)):
+                    or not isinstance(msgid, basestring)):
                 return
-            # Support gettext "extracted comments" on tagged fields. This is
-            # consistent with extracted comments in templates, which follow
-            # the format "{#: Extracted comment. #}". An example:
+            # Support gettext "extracted comments" on tagged fields:
             #   field@: Message.
             #   field@#: Extracted comment for field@.
             auto_comments = []
@@ -194,139 +158,131 @@ class Catalogs(object):
                 auto_comment = node.get('{}#'.format(key))
                 if auto_comment:
                     auto_comments.append(auto_comment)
-            locations = [(path, 0)]
-            _add_existing_message(
-                msgid=item,
+            message = catalog.Message(
+                msgid,
+                None,
                 auto_comments=auto_comments,
-                locations=locations,
-                path=path)
+                # TODO: line numbers
+                locations=[(path, 0)])
 
+            _add_to_catalog(message, locales)
+
+        def _babel_extract(fp, locales, path):
+            try:
+                all_parts = extract.extract(
+                    'jinja2.ext.babel_extract',
+                    fp,
+                    options=options,
+                    comment_tags=comment_tags)
+                for parts in all_parts:
+                    lineno, msgid, comments, context = parts
+                    message = catalog.Message(
+                        msgid,
+                        None,
+                        auto_comments=comments,
+                        locations=[(path, lineno)])
+                    _add_to_catalog(message, locales)
+            except tokenize.TokenError:
+                self.pod.logger.error('Problem extracting body: {}'.format(path))
+                raise
+
+        # Extract from collections in /content/:
+        # Strings only extracted for relevant locales, determined by locale
+        # scope (pod > collection > document > document part)
         for collection in self.pod.list_collections():
-            text = 'Extracting collection: {}'.format(collection.pod_path)
-            self.pod.logger.info(text)
             for doc in collection.list_docs(include_hidden=True):
-                if not self._should_extract_as_babel(paths, doc.pod_path):
-                    continue
-                tagged_fields = doc.get_tagged_fields()
-                utils.walk(tagged_fields, lambda *args: callback(doc, *args))
-                paths_to_locales[doc.pod_path].update(doc.locales)
-                all_locales.update(doc.locales)
+                self.pod.logger.info('Extracting: {}'.format(doc.pod_path))
 
-        # Extract from podspec.
-        config = self.pod.get_podspec().get_config()
-        podspec_path = '/podspec.yaml'
-        if self._should_extract_as_babel(paths, podspec_path):
-            self.pod.logger.info('Extracting podspec: {}'.format(podspec_path))
-            utils.walk(config, lambda *args: _handle_field(podspec_path, *args))
-
-        # Extract from content and views.
-        pod_files = [os.path.join('/views', path)
-                     for path in self.pod.list_dir('/views/')]
-        pod_files += [os.path.join('/content', path)
-                      for path in self.pod.list_dir('/content/')]
-        pod_files += [os.path.join('/data', path)
-                      for path in self.pod.list_dir('/data/')]
-        for pod_path in pod_files:
-            if self._should_extract_as_csv(paths, pod_path):
-                rows = utils.get_rows_from_csv(self.pod, pod_path)
-                self.pod.logger.info('Extracting: {}'.format(pod_path))
-                for row in rows:
-                    for i, parts in enumerate(row.iteritems()):
-                        key, val = parts
-                        if key.endswith('@'):
-                            locations = [(pod_path, i)]
-                            _add_existing_message(
-                                msgid=val,
-                                locations=locations,
-                                path=pod_path)
-            elif self._should_extract_as_babel(paths, pod_path):
-                if pod_path.startswith('/data') and pod_path.endswith(('.yaml', '.yml')):
-                    self.pod.logger.info('Extracting: {}'.format(pod_path))
-                    content = self.pod.read_file(pod_path)
-                    fields = utils.load_yaml(content, pod=self.pod)
-                    utils.walk(fields, lambda *args: _handle_field(pod_path, *args))
-                    continue
-
-                pod_locales = paths_to_locales.get(pod_path)
-                if pod_locales:
-                    text = 'Extracting: {} ({} locales)'
-                    text = text.format(pod_path, len(pod_locales))
-                    self.pod.logger.info(text)
+                # If doc.locale is set, this is a doc part: only extract for
+                # its own locales (not those of base doc).
+                if doc.locale:
+                    doc_locales = [doc.locale]
+                # If not is set, this is a base doc (1st or only part): extract
+                # for all locales declared for this doc
+                elif doc.locales:
+                    doc_locales = doc.locales
+                # Otherwise only include in template (--no-localized)
                 else:
-                    self.pod.logger.info('Extracting: {}'.format(pod_path))
-                fp = self.pod.open_file(pod_path)
-                try:
-                    all_parts = extract.extract(
-                        'jinja2.ext.babel_extract', fp, options=options,
-                        comment_tags=comment_tags)
-                    for parts in all_parts:
-                        lineno, string, comments, context = parts
-                        locations = [(pod_path, lineno)]
-                        _add_existing_message(
-                            msgid=string,
-                            auto_comments=comments,
-                            context=context,
-                            locations=locations,
-                            path=pod_path)
-                except tokenize.TokenError:
-                    self.pod.logger.error('Problem extracting: {}'.format(pod_path))
-                    raise
+                    doc_locales = [None]
 
-        # Localized message catalogs.
+                # Extract yaml fields: `foo@: Extract me`
+                # ("tagged" = prior to stripping `@` suffix from field names)
+                tagged_fields = doc.get_tagged_fields()
+                utils.walk(tagged_fields,
+                           lambda *args: _handle_field(doc.pod_path, doc_locales, *args))
+
+                # Extract body: {{_('Extract me')}}
+                _babel_extract(StringIO.StringIO(doc.body.encode('utf-8')), doc_locales, doc.pod_path)
+
+            # Extract from CSVs for this collection's locales
+            for filepath in self.pod.list_dir(collection.pod_path):
+                if filepath.endswith('.csv'):
+                    pod_path = os.path.join(collection.pod_path, filepath.lstrip('/'))
+                    self.pod.logger.info('Extracting: {}'.format(pod_path))
+                    rows = self.pod.read_csv(pod_path)
+                    for i, row in enumerate(rows):
+                        for key, msgid in row.iteritems():
+                            _handle_field(pod_path, collection.list_locales(), msgid, key, row)
+
+        # Extract from root of /content/:
+        for path in self.pod.list_dir('/content/', recursive=False):
+            if path.endswith('.yaml') or path.endswith('.yml'):
+                pod_path = os.path.join('/content/', path)
+                self.pod.logger.info('Extracting: {}'.format(pod_path))
+                utils.walk(
+                    self.pod.get_doc(pod_path).get_tagged_fields(),
+                    lambda *args: _handle_field(pod_path, self.pod.list_locales(), *args)
+                )
+
+        # Extract from /views/:
+        # Not discriminating by file extension, because people use all sorts
+        # (htm, html, tpl, dtml, jtml, ...)
+        for path in self.pod.list_dir('/views/'):
+            pod_path = os.path.join('/views/', path)
+            self.pod.logger.info('Extracting: {}'.format(pod_path))
+            with self.pod.open_file(pod_path) as f:
+                _babel_extract(f, self.pod.list_locales(), pod_path)
+
+        # Extract from podspec.yaml:
+        self.pod.logger.info('Extracting: podspec.yaml')
+        utils.walk(
+            self.pod.get_podspec().get_config(),
+            lambda *args: _handle_field('/podspec.yaml', self.pod.list_locales(), *args)
+        )
+
+        # Save it out: behavior depends on --localized and --locale flags
         if localized:
-            for locale in all_locales:
+            # Save each localized catalog
+            for locale, new_catalog in localized_catalogs.items():
+                # Skip if `locales` defined but doesn't include this locale
                 if locales and locale not in locales:
                     continue
-                localized_catalog = self.get(locale)
-                if not include_obsolete:
-                    localized_catalog.obsolete = babel_util.odict()
-                    for message in list(localized_catalog):
-                        if message.id not in message_ids_to_messages:
-                            localized_catalog.delete(message.id, context=message.context)
-
-                catalog_to_merge = catalog.Catalog()
-                for path, message_items in paths_to_messages.iteritems():
-                    locales_with_this_path = paths_to_locales.get(path)
-                    if locales_with_this_path and locale not in locales_with_this_path:
-                        continue
-                    for message in message_items:
-                        translation = None
-                        existing_message = localized_catalog.get(message.id)
-                        if existing_message:
-                            translation = existing_message.string
-                        catalog_to_merge.add(
-                            message.id, translation, locations=message.locations,
-                            auto_comments=message.auto_comments, flags=message.flags,
-                            user_comments=message.user_comments, context=message.context,
-                            lineno=message.lineno, previous_id=message.previous_id)
-
-                localized_catalog.update_using_catalog(
-                    catalog_to_merge, use_fuzzy_matching=use_fuzzy_matching)
-                localized_catalog.save(include_header=include_header)
-                missing = localized_catalog.list_untranslated()
-                num_messages = len(localized_catalog)
-                num_translated = num_messages - len(missing)
-                text = 'Saved: /{path} ({num_translated}/{num_messages})'
+                existing_catalog = self.get(locale)
+                existing_catalog.update_using_catalog(
+                    new_catalog,
+                    include_obsolete=include_obsolete)
+                existing_catalog.save(include_header=include_header)
+                missing = existing_catalog.list_untranslated()
+                num_messages = len(existing_catalog)
                 self.pod.logger.info(
-                    text.format(path=localized_catalog.pod_path,
-                                num_translated=num_translated,
-                                num_messages=num_messages))
-            return
-
-        # Global (or missing, specified by -o) message catalog.
-        template_path = self.template_path
-        catalog_obj, _ = self._get_or_create_catalog(template_path)
-        if not include_obsolete:
-            catalog_obj.obsolete = babel_util.odict()
-            for message in list(catalog_obj):
-                catalog_obj.delete(message.id, context=message.context)
-        for message in message_ids_to_messages.itervalues():
-            if message.id:
-                catalog_obj.add(message.id, None, locations=message.locations,
-                                auto_comments=message.auto_comments)
-        return self.write_template(
-            template_path, catalog_obj, include_obsolete=include_obsolete,
-            include_header=include_header)
+                    'Saved: /{path} ({num_translated}/{num_messages})'.format(
+                        path=existing_catalog.pod_path,
+                        num_translated=num_messages - len(missing),
+                        num_messages=num_messages)
+                    )
+        else:
+            # --localized omitted / --no-localized
+            template_catalog = self.get_template()
+            template_catalog.load()
+            template_catalog.update_using_catalog(
+                unlocalized_catalog,
+                include_obsolete=include_obsolete)
+            template_catalog.save(include_header=include_header)
+            text = 'Saved: {} ({} messages)'
+            self.pod.logger.info(
+                text.format(template_catalog.pod_path, len(template_catalog))
+            )
+            return template_catalog
 
     def write_template(self, template_path, catalog, include_obsolete=False,
                        include_header=False):

--- a/grow/pods/catalog_holder_test.py
+++ b/grow/pods/catalog_holder_test.py
@@ -407,6 +407,24 @@ class ExtractLocalizedTest(_BaseExtractLocalizedTest):
             u'Localized yaml doc part in localized doc in unlocalized collection in unlocalized pöd',
             'ja')
 
+    def test_yaml_part_in_unlocalized_doc_extracted_for_own_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part in unlocalized doc in localized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part in unlocalized doc in unlocalized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part in unlocalized doc in localized collection in unlocalized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part in unlocalized doc in unlocalized collection in unlocalized pöd',
+            'ja')
+
     def test_multilocale_yaml_part_extracted_for_own_locales(self):
         self.assertExtractedFor(
             self.localized_pod,
@@ -452,11 +470,23 @@ class ExtractLocalizedTest(_BaseExtractLocalizedTest):
             self.unlocalized_pod,
             u'Unlocalized yaml doc in localized collection in unlocalized pöd',
             'fr')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized base doc part in localized collection in localized pöd',
+            'fr')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized base doc part in localized collection in unlocalized pöd',
+            'fr')
 
     def test_yaml_doc_extracted_for_podspec_locales(self):
         self.assertExtractedFor(
             self.localized_pod,
             u'Unlocalized yaml doc in unlocalized collection in localized pöd',
+            'de')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized base doc part in unlocalized collection in localized pöd',
             'de')
 
     def test_yaml_doc_extracted_for_no_locales(self):
@@ -464,6 +494,10 @@ class ExtractLocalizedTest(_BaseExtractLocalizedTest):
             self.unlocalized_pod,
             u'Unlocalized yaml doc in unlocalized collection in unlocalized pöd',
             [])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized base doc part in unlocalized collection in unlocalized pöd',
+            'de')
 
     # ------------------------------------------------
     # YAML files in /content/ root

--- a/grow/pods/catalog_holder_test.py
+++ b/grow/pods/catalog_holder_test.py
@@ -1,7 +1,9 @@
+# coding: utf-8
+import unittest
+
 from grow.pods import pods
 from grow.pods import storage
 from grow.testing import testing
-import unittest
 
 
 class CatalogsTest(unittest.TestCase):
@@ -128,6 +130,575 @@ class CatalogsTest(unittest.TestCase):
         localized_fr_catalog = catalogs[1]
         self.assertEqual(3, len(localized_de_catalog))
         self.assertEqual(14, len(localized_fr_catalog))
+
+
+class _BaseExtractLocalizedTest(unittest.TestCase):
+    # Both localized_pod and unlocalized_pod fixtures use these locales
+    ALL_LOCALES = (
+        'de',    # declared for podspec
+        'fr',    # declared for blueprint
+        'it',    # declared for a doc base part
+        'ja',    # declared for a doc part
+        'sv',    # declared for multi-locale doc parts
+    )
+
+    # Assert `message` appears in catalogs for all `locales`, and does NOT
+    # appear in other catalogs in ALL_LOCALES
+    def assertExtractedFor(self, pod, message, locales):
+        # If `locales` is a string, assume single locale & coerce to iterable
+        locales = (locales,) if isinstance(locales, basestring) else locales
+        for locale in self.ALL_LOCALES:
+            if locale in locales:
+                self.assertIn(message, pod.catalogs.get(locale))
+            else:
+                self.assertNotIn(message, pod.catalogs.get(locale))
+
+
+class ExtractLocalizedTest(_BaseExtractLocalizedTest):
+    # setUpClass rather than setUp to only do this once & hence speed up tests
+    # NOTE: Pods should NOT be modified by test cases
+    @classmethod
+    def setUpClass(cls):
+        cls.localized_pod = testing.create_test_pod('extract_localized/localized_pod')
+        cls.localized_pod.catalogs.compile()
+        cls.localized_pod.catalogs.extract(localized=True)
+        cls.unlocalized_pod = testing.create_test_pod('extract_localized/unlocalized_pod')
+        cls.unlocalized_pod.catalogs.compile()
+        cls.unlocalized_pod.catalogs.extract(localized=True)
+
+    # NOTE: All tests should mix ASCII & non-ASCII chars
+
+    # ================================================================
+    # Document contexts (in /content/)
+    # ================================================================
+
+    # ------------------------------------------------
+    # HTML document body
+    # ------------------------------------------------
+
+    def test_body_of_doc_part_extracted_for_part_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part body in localized doc in localized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part body in localized doc in unlocalized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part body in localized doc in localized collection in unlocalized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part body in localized doc in unlocalized collection in unlocalized pöd',
+            'ja')
+
+    def test_body_of_multilocale_doc_part_extracted_for_part_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale doc part body in localized doc in localized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale doc part body in localized doc in unlocalized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale doc part body in localized doc in localized collection in unlocalized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale doc part body in localized doc in unlocalized collection in unlocalized pöd',
+            ['it', 'sv'])
+
+    def test_body_of_doc_extracted_for_doc_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc in localized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc in unlocalized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc in localized collection in unlocalized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc in unlocalized collection in unlocalized pöd',
+            'it')
+
+    def test_body_of_base_doc_part_extracted_for_doc_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized multipart doc base part body in localized collection in localized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized multipart doc base part body in unlocalized collection in localized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized multipart doc base part body in localized collection in unlocalized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized multipart doc base part body in unlocalized collection in unlocalized pöd',
+            ['it', 'ja', 'sv'])
+
+    def test_body_of_doc_extracted_for_collection_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized doc body in localized collection in localized pöd',
+            'fr')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized doc body in localized collection in unlocalized pöd',
+            'fr')
+
+    def test_body_of_doc_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized doc body in unlocalized collection in localized pöd',
+            'de')
+
+    def test_body_of_doc_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized doc body in unlocalized collection in unlocalized pöd',
+            [])
+
+    # ------------------------------------------------
+    # Markdown document body
+    # > should NEVER be extracted: template tags in MD
+    #   don't work so the term would never be rendered
+    # ------------------------------------------------
+    @unittest.expectedFailure
+    # TODO: Currently extracting from MD is erroneously allowed
+    def test_body_of_md_doc_never_extracted(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            'Untranslatable MD doc body',
+            [])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            'Untranslatable MD doc body',
+            [])
+
+    # ------------------------------------------------
+    # YAML front matter of HTML/MD docs
+    # ------------------------------------------------
+
+    def test_doc_part_front_matter_extracted_for_part_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part front matter in localized doc in localized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc part front matter in localized doc in unlocalized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part front matter in localized doc in localized collection in unlocalized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc part front matter in localized doc in unlocalized collection in unlocalized pöd',
+            'ja')
+
+    def test_doc_part_front_matter_extracted_for_multiple_part_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale doc part front matter in localized doc in localized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale doc part front matter in localized doc in localized collection in unlocalized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in unlocalized pöd',
+            ['it', 'sv'])
+
+    def test_base_doc_part_front_matter_extracted_for_doc_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized base doc front matter in localized collection in localized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized base doc front matter in unlocalized collection in localized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized base doc front matter in localized collection in unlocalized pöd',
+            ['it', 'ja', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized base doc front matter in unlocalized collection in unlocalized pöd',
+            ['it', 'ja', 'sv'])
+
+    def test_doc_front_matter_extracted_for_doc_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc front matter in localized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized doc front matter in unlocalized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc front matter in localized collection in unlocalized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized doc front matter in unlocalized collection in unlocalized pöd',
+            'it')
+
+    def test_doc_front_matter_extracted_for_collection_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized doc front matter in localized collection in localized pöd',
+            'fr')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized doc front matter in localized collection in unlocalized pöd',
+            'fr')
+
+    def test_doc_front_matter_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized doc front matter in unlocalized collection in localized pöd',
+            'de')
+
+    def test_doc_front_matter_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized doc front matter in unlocalized collection in unlocalized pöd',
+            [])
+
+    # --------------------------------
+    # YAML docs in collections
+    # --------------------------------
+
+    def test_yaml_part_extracted_for_own_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized yaml doc part in localized doc in localized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized yaml doc part in localized doc in unlocalized collection in localized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized yaml doc part in localized doc in localized collection in unlocalized pöd',
+            'ja')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized yaml doc part in localized doc in unlocalized collection in unlocalized pöd',
+            'ja')
+
+    def test_multilocale_yaml_part_extracted_for_own_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale yaml doc part in localized doc in localized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Multi-locale yaml doc part in localized doc in unlocalized collection in localized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale yaml doc part in localized doc in localized collection in unlocalized pöd',
+            ['it', 'sv'])
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Multi-locale yaml doc part in localized doc in unlocalized collection in unlocalized pöd',
+            ['it', 'sv'])
+
+    def test_yaml_doc_extracted_for_own_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized yaml doc in localized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Localized yaml doc in unlocalized collection in localized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized yaml doc in localized collection in unlocalized pöd',
+            'it')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Localized yaml doc in unlocalized collection in unlocalized pöd',
+            'it')
+
+    def test_yaml_doc_extracted_for_collection_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized yaml doc in localized collection in localized pöd',
+            'fr')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized yaml doc in localized collection in unlocalized pöd',
+            'fr')
+
+    def test_yaml_doc_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Unlocalized yaml doc in unlocalized collection in localized pöd',
+            'de')
+
+    def test_yaml_doc_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized yaml doc in unlocalized collection in unlocalized pöd',
+            [])
+
+    # ------------------------------------------------
+    # YAML files in /content/ root
+    # ------------------------------------------------
+    def test_yaml_in_content_root_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'YAML in content dir root in localized pöd',
+            'de')
+
+    def test_yaml_in_content_root_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'YAML in content dir root in unlocalized pöd',
+            [])
+
+    # ------------------------------------------------
+    # CSV docs
+    # ------------------------------------------------
+
+    def test_csv_extracted_for_collection_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'CSV in localized collection in localized pöd',
+            'fr')
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'CSV in localized collection in unlocalized pöd',
+            'fr')
+
+    def test_csv_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'CSV in unlocalized collection in localized pöd',
+            'de')
+
+    def test_csv_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'CSV in unlocalized collection in unlocalized pöd',
+            [])
+
+    # ================================================================
+    # In podspec.yaml
+    # ================================================================
+
+    def test_podspec_extracted_for_own_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            'Localized podspec',
+            'de')
+
+    def test_podspec_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Unlocalized pödspec',
+            [])
+
+    # ================================================================
+    # In templates (in /views/)
+    # ================================================================
+
+    def test_template_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Template in localized pöd',
+            'de')
+
+    def test_nested_template_extracted_for_podspec_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Template in subdir in localized pöd',
+            'de')
+
+    def test_template_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.unlocalized_pod,
+            u'Template in unlocalized pöd',
+            [])
+
+    def test_nested_template_extracted_for_no_locales(self):
+        self.assertExtractedFor(
+            self.localized_pod,
+            u'Template in subdir in unlocalized pöd',
+            [])
+
+
+class ExtractLocalizedWithExistingTest(_BaseExtractLocalizedTest):
+    # Test behaviour when there are existing translations
+
+    def test_excludes_obsolete_by_default(self):
+        pod = testing.create_test_pod('extract_localized/localized_pod')
+        pod.catalogs.compile()
+        pod.catalogs.extract(localized=True, locales=['fr'])
+
+        self.assertExtractedFor(pod, u'Existing message in localized pöd', [])
+        # we don't use gettext syntax for obsolete translations
+        for locale in self.ALL_LOCALES:
+            self.assertFalse(pod.catalogs.get(locale).obsolete)
+
+    def test_include_obsolete_option(self):
+        pod = testing.create_test_pod('extract_localized/localized_pod')
+        pod.catalogs.compile()
+        pod.catalogs.extract(localized=True, locales=['fr'], include_obsolete=True)
+
+        message = u'Existing message in localized pöd'
+        translation = u'Existing FR translation in localized pöd'
+
+        self.assertExtractedFor(pod, message, ['fr'])
+        self.assertEqual(
+            pod.catalogs.get('fr').gettext_translations.gettext(message),
+            translation.encode('utf-8')
+        )
+
+        # we don't use gettext syntax for obsolete translations
+        for locale in self.ALL_LOCALES:
+            self.assertFalse(pod.catalogs.get(locale).obsolete)
+
+
+class ExtractLocalizedSpecificLocalesTest(_BaseExtractLocalizedTest):
+
+    def test_extract_localized_for_single_locale(self):
+        localized_pod = testing.create_test_pod('extract_localized/localized_pod')
+        localized_pod.catalogs.compile()
+        localized_pod.catalogs.extract(localized=True, locales=['it'])
+
+        unlocalized_pod = testing.create_test_pod('extract_localized/unlocalized_pod')
+        unlocalized_pod.catalogs.compile()
+        unlocalized_pod.catalogs.extract(localized=True, locales=['it'])
+
+        # These strings are all relevant to both IT & SV, but should only be
+        # extracted for IT
+        italian_messages = (
+            u'Multi-locale doc part body in localized doc in localized collection in localized pöd',
+            u'Multi-locale doc part body in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale doc part body in localized doc in localized collection in unlocalized pöd',
+            u'Multi-locale doc part body in localized doc in unlocalized collection in unlocalized pöd',
+            u'Multi-locale doc part front matter in localized doc in localized collection in localized pöd',
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale doc part front matter in localized doc in localized collection in unlocalized pöd',
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in unlocalized pöd',
+            u'Multi-locale yaml doc part in localized doc in localized collection in localized pöd',
+            u'Multi-locale yaml doc part in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale yaml doc part in localized doc in localized collection in unlocalized pöd',
+        )
+        for message in italian_messages:
+            if u'unlocalized pöd' in message:
+                self.assertExtractedFor(unlocalized_pod, message, 'it')
+            else:
+                self.assertExtractedFor(localized_pod, message, 'it')
+
+        # These are only relevant to FR, DE or no locales, so shouldn't be extracted
+        non_italian_messages = (
+            u'Unlocalized doc body in localized collection in localized pöd',
+            u'Unlocalized doc body in localized collection in unlocalized pöd',
+            u'Unlocalized doc body in unlocalized collection in localized pöd',
+            u'Unlocalized doc body in unlocalized collection in unlocalized pöd',
+            u'Unlocalized doc front matter in localized collection in localized pöd',
+            u'Unlocalized doc front matter in localized collection in unlocalized pöd',
+            u'Unlocalized doc front matter in unlocalized collection in localized pöd',
+            u'Unlocalized doc front matter in unlocalized collection in unlocalized pöd',
+            u'Unlocalized yaml doc in localized collection in localized pöd',
+            u'Unlocalized yaml doc in localized collection in unlocalized pöd',
+            u'Unlocalized yaml doc in unlocalized collection in localized pöd',
+            u'Unlocalized yaml doc in unlocalized collection in unlocalized pöd',
+            u'Unlocalized pödspec',
+        )
+
+        for message in non_italian_messages:
+            if u'unlocalized pöd' in message:
+                self.assertExtractedFor(unlocalized_pod, message, [])
+            else:
+                self.assertExtractedFor(localized_pod, message, [])
+
+    def test_extract_localized_for_multiple_locales(self):
+        localized_pod = testing.create_test_pod('extract_localized/localized_pod')
+        localized_pod.catalogs.compile()
+        localized_pod.catalogs.extract(localized=True, locales=['it', 'sv', 'de'])
+
+        unlocalized_pod = testing.create_test_pod('extract_localized/unlocalized_pod')
+        unlocalized_pod.catalogs.compile()
+        unlocalized_pod.catalogs.extract(localized=True, locales=['it', 'sv', 'de'])
+
+        # These strings are all relevant to both IT & SV
+        it_sv_messages = (
+            u'Multi-locale doc part body in localized doc in localized collection in localized pöd',
+            u'Multi-locale doc part body in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale doc part body in localized doc in localized collection in unlocalized pöd',
+            u'Multi-locale doc part body in localized doc in unlocalized collection in unlocalized pöd',
+            u'Multi-locale doc part front matter in localized doc in localized collection in localized pöd',
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale doc part front matter in localized doc in localized collection in unlocalized pöd',
+            u'Multi-locale doc part front matter in localized doc in unlocalized collection in unlocalized pöd',
+            u'Multi-locale yaml doc part in localized doc in localized collection in localized pöd',
+            u'Multi-locale yaml doc part in localized doc in unlocalized collection in localized pöd',
+            u'Multi-locale yaml doc part in localized doc in localized collection in unlocalized pöd',
+        )
+        for message in it_sv_messages:
+            if u'unlocalized pöd' in message:
+                self.assertExtractedFor(unlocalized_pod, message, ['it', 'sv'])
+            else:
+                self.assertExtractedFor(localized_pod, message, ['it', 'sv'])
+
+        # These are only relevant to DE
+        de_messages = (
+            u'Unlocalized doc body in unlocalized collection in localized pöd',
+            u'Unlocalized doc front matter in unlocalized collection in localized pöd',
+            u'Unlocalized yaml doc in unlocalized collection in localized pöd',
+        )
+
+        for message in de_messages:
+            if u'unlocalized pöd' in message:
+                self.assertExtractedFor(unlocalized_pod, message, ['de'])
+            else:
+                self.assertExtractedFor(localized_pod, message, ['de'])
+
+        # These are only relevant to FR or no locales, so shouldn't be extracted
+        fr_messages = (
+            u'Unlocalized doc body in localized collection in localized pöd',
+            u'Unlocalized doc body in localized collection in unlocalized pöd',
+            u'Unlocalized doc body in unlocalized collection in unlocalized pöd',
+            u'Unlocalized doc front matter in localized collection in localized pöd',
+            u'Unlocalized doc front matter in localized collection in unlocalized pöd',
+            u'Unlocalized doc front matter in unlocalized collection in unlocalized pöd',
+            u'Unlocalized yaml doc in localized collection in localized pöd',
+            u'Unlocalized yaml doc in localized collection in unlocalized pöd',
+            u'Unlocalized yaml doc in unlocalized collection in unlocalized pöd',
+            u'Unlocalized pödspec',
+        )
+
+        for message in fr_messages:
+            if u'unlocalized pöd' in message:
+                self.assertExtractedFor(unlocalized_pod, message, [])
+            else:
+                self.assertExtractedFor(localized_pod, message, [])
 
 
 if __name__ == '__main__':

--- a/grow/pods/catalogs.py
+++ b/grow/pods/catalogs.py
@@ -2,6 +2,7 @@ from babel import util
 from babel.messages import catalog
 from babel.messages import mofile
 from babel.messages import pofile
+from babel.util import odict
 from datetime import datetime
 from grow.pods import messages
 from grow.pods.storage import gettext_storage as gettext
@@ -125,8 +126,11 @@ class Catalog(catalog.Catalog):
                              include_obsolete=False):
         super(Catalog, self).update(
             catalog_to_merge, no_fuzzy_matching=(not use_fuzzy_matching))
+        # Don't use gettext's obsolete functionality as it polutes files: merge
+        # into main translations if anything
         if include_obsolete:
             self.merge_obsolete()
+        self.obsolete = odict()
 
     def update(self, template_path=None, use_fuzzy_matching=False,
                include_obsolete=False, include_header=False):
@@ -140,8 +144,11 @@ class Catalog(catalog.Catalog):
         template = pofile.read_po(template_file)
         super(Catalog, self).update(
             template, no_fuzzy_matching=(not use_fuzzy_matching))
+        # Don't use gettext's obsolete functionality as it polutes files: merge
+        # into main translations if anything
         if include_obsolete:
             self.merge_obsolete()
+        self.obsolete = odict()
         self.save(include_header=include_header)
 
     def merge_obsolete(self):

--- a/grow/pods/catalogs.py
+++ b/grow/pods/catalogs.py
@@ -152,7 +152,7 @@ class Catalog(catalog.Catalog):
         self.save(include_header=include_header)
 
     def merge_obsolete(self):
-        """ Copy obsolete terms into the main catalog """
+        """Copy obsolete terms into the main catalog."""
         for msgid, message in self.obsolete.iteritems():
             self[msgid] = message
 

--- a/grow/pods/catalogs.py
+++ b/grow/pods/catalogs.py
@@ -100,16 +100,19 @@ class Catalog(catalog.Catalog):
             catalog_message.messages.append(message_message)
         return catalog_message
 
-    def save(self, ignore_obsolete=True, include_previous=True, width=80,
-             include_header=False):
+    def save(self, include_header=False):
         if not self.pod.file_exists(self.pod_path):
             self.pod.create_file(self.pod_path, None)
         outfile = self.pod.open_file(self.pod_path, mode='w')
         Catalog.set_header_comment(self.pod, self)
         pofile.write_po(
-            outfile, self, omit_header=(not include_header), sort_output=True,
-            sort_by_file=True, ignore_obsolete=ignore_obsolete,
-            include_previous=include_previous, width=width)
+            outfile,
+            self,
+            omit_header=(not include_header),
+            sort_output=True,
+            sort_by_file=True,
+            include_previous=True,
+            width=80)
         outfile.close()
 
     def init(self, template_path, include_header=False):
@@ -118,13 +121,15 @@ class Catalog(catalog.Catalog):
         self.fuzzy = False
         self.save(include_header=include_header)
 
-    def update_using_catalog(self, catalog_to_merge, use_fuzzy_matching=False):
+    def update_using_catalog(self, catalog_to_merge, use_fuzzy_matching=False,
+                             include_obsolete=False):
         super(Catalog, self).update(
             catalog_to_merge, no_fuzzy_matching=(not use_fuzzy_matching))
+        if include_obsolete:
+            self.merge_obsolete()
 
     def update(self, template_path=None, use_fuzzy_matching=False,
-               ignore_obsolete=True, include_previous=True, width=80,
-               include_header=False):
+               include_obsolete=False, include_header=False):
         """Updates catalog with messages from a template."""
         if template_path is None:
             template_path = os.path.join('translations', 'messages.pot')
@@ -135,9 +140,14 @@ class Catalog(catalog.Catalog):
         template = pofile.read_po(template_file)
         super(Catalog, self).update(
             template, no_fuzzy_matching=(not use_fuzzy_matching))
-        self.save(ignore_obsolete=ignore_obsolete,
-                  include_previous=include_previous, width=width,
-                  include_header=include_header)
+        if include_obsolete:
+            self.merge_obsolete()
+        self.save(include_header=include_header)
+
+    def merge_obsolete(self):
+        """ Copy obsolete terms into the main catalog """
+        for msgid, message in self.obsolete.iteritems():
+            self[msgid] = message
 
     @property
     def mo_path(self):

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -136,7 +136,7 @@ class DocumentsTestCase(unittest.TestCase):
             ))
 
         with self.assertRaises(formats.BadFormatError):
-            self.pod.get_doc('/content/localized/part-with-no-locale.yaml')
+            self.pod.get_doc('/' + doc_pod_path)
 
         # This should be fine:
         with open(os.path.join(self.pod.root, doc_pod_path), 'w') as f:
@@ -154,10 +154,27 @@ class DocumentsTestCase(unittest.TestCase):
                 foo: bar
                 """
             ))
-        de_doc = self.pod.get_doc('/content/localized/part-with-no-locale.yaml', locale='de')
-        fr_doc = self.pod.get_doc('/content/localized/part-with-no-locale.yaml', locale='fr')
+        de_doc = self.pod.get_doc('/' + doc_pod_path, locale='de')
+        fr_doc = self.pod.get_doc('/' + doc_pod_path, locale='fr')
         self.assertEqual(de_doc.fields['foo'], 'bar')
         self.assertNotIn('foo', fr_doc.fields)
+
+    def test_dont_treat_trailing_dashes_as_a_new_part(self):
+        doc_pod_path = 'content/localized/part-with-trailing-dashes.yaml'
+        with open(os.path.join(self.pod.root, doc_pod_path), 'w') as f:
+            f.write(dedent(
+                """\
+                ---
+                root_doc_part: true
+                ---
+                $locale: de
+                subsequent_doc_part: true
+                ---
+                """
+            ))
+
+        doc = self.pod.get_doc('/' + doc_pod_path)
+        self.assertEqual(len(doc.format._iterate_content()), 2)
 
     def test_view_override(self):
         doc = self.pod.get_doc('/content/localized/localized-view-override.yaml')

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -1,8 +1,12 @@
+import os
+from textwrap import dedent
+import unittest
+
+from grow.pods import formats
 from grow.pods import locales
 from grow.pods import pods
 from grow.pods import storage
 from grow.testing import testing
-import unittest
 
 
 class DocumentsTestCase(unittest.TestCase):
@@ -112,6 +116,48 @@ class DocumentsTestCase(unittest.TestCase):
         self.assertEqual('base', doc.foo)
         self.assertEqual('baz', doc.bar)
         self.assertEqual('/intl/fr/localized/', doc.url.path)
+
+    def test_disallow_part_with_no_locale(self):
+        # Doc parts must either define $locale or $locales.
+        # Add test file dynamically, otherwise it'll error when other tests run
+        doc_pod_path = 'content/localized/part-with-no-locale.yaml'
+        with open(os.path.join(self.pod.root, doc_pod_path), 'w') as f:
+            f.write(dedent(
+                """\
+                ---
+                $title: Multiple Locales
+                $localization:
+                  path: /intl/{locale}/multiple-locales/
+                  locales:
+                  - de
+                ---
+                foo: bar
+                """
+            ))
+
+        with self.assertRaises(formats.BadFormatError):
+            self.pod.get_doc('/content/localized/part-with-no-locale.yaml')
+
+        # This should be fine:
+        with open(os.path.join(self.pod.root, doc_pod_path), 'w') as f:
+            f.write(dedent(
+                """\
+                ---
+                $title: Multiple Locales
+                $localization:
+                  path: /intl/{locale}/multiple-locales/
+                  locales:
+                  - de
+                  - fr
+                ---
+                $locale: de
+                foo: bar
+                """
+            ))
+        de_doc = self.pod.get_doc('/content/localized/part-with-no-locale.yaml', locale='de')
+        fr_doc = self.pod.get_doc('/content/localized/part-with-no-locale.yaml', locale='fr')
+        self.assertEqual(de_doc.fields['foo'], 'bar')
+        self.assertNotIn('foo', fr_doc.fields)
 
     def test_view_override(self):
         doc = self.pod.get_doc('/content/localized/localized-view-override.yaml')

--- a/grow/pods/formats.py
+++ b/grow/pods/formats.py
@@ -80,7 +80,10 @@ class Format(object):
 class _SplitDocumentFormat(Format):
 
     def _iterate_content(self):
-        return [(part, part) for part in Format.split_front_matter(self.content)]
+        parts = [(part, part) for part in Format.split_front_matter(self.content)]
+        if not parts[-1][0].strip():
+            parts.pop()
+        return parts
 
     def _validate_fields(self, fields):
         if '$locale' in fields and '$locales' in fields:

--- a/grow/pods/formats.py
+++ b/grow/pods/formats.py
@@ -87,6 +87,17 @@ class _SplitDocumentFormat(Format):
             text = 'You must specify either $locale or $locales, not both.'
             raise BadFormatError(text)
 
+    def _validate_base_part(self, fields):
+        self._validate_fields(fields)
+
+    def _validate_non_base_part(self, fields):
+        # Any additional parts after base part MUST declare one or more locales
+        # (otherwise there's no point)
+        if '$locale' not in fields and '$locales' not in fields:
+            text = 'You must specify either $locale or $locales.'
+            raise BadFormatError(text)
+        self._validate_fields(fields)
+
     def _get_locales_of_part(self, fields):
         if '$locales' in fields:
             return fields['$locales']
@@ -119,9 +130,11 @@ class _SplitDocumentFormat(Format):
         for i, parts in enumerate(self._iterate_content()):
             part, body = parts
             fields = self._load_yaml(part)
-            self._validate_fields(fields)
             if i == 0:
+                self._validate_base_part(fields)
                 base_default_locale = self._get_base_default_locale(fields)
+            else:
+                self._validate_non_base_part(fields)
             for part_locale in self._get_locales_of_part(fields):
                 locales_to_fields[part_locale] = fields
                 locales_to_bodies[part_locale] = body

--- a/grow/pods/formats.py
+++ b/grow/pods/formats.py
@@ -94,7 +94,7 @@ class _SplitDocumentFormat(Format):
         # Any additional parts after base part MUST declare one or more locales
         # (otherwise there's no point)
         if '$locale' not in fields and '$locales' not in fields:
-            text = 'You must specify either $locale or $locales.'
+            text = 'You must specify either $locale or $locales for each document part.'
             raise BadFormatError(text)
         self._validate_fields(fields)
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -166,9 +166,9 @@ class Pod(object):
           raise ValueError('.. not allowed in file paths.')
         return os.path.join(self.root, pod_path.lstrip('/'))
 
-    def list_dir(self, pod_path='/'):
+    def list_dir(self, pod_path='/', recursive=True):
         path = self._normalize_path(pod_path)
-        return self.storage.listdir(path)
+        return self.storage.listdir(path, recursive)
 
     def open_file(self, pod_path, mode=None):
         path = self._normalize_path(pod_path)

--- a/grow/pods/storage/base_storage.py
+++ b/grow/pods/storage/base_storage.py
@@ -23,7 +23,7 @@ class BaseStorage(object):
         raise NotImplementedError
 
     @staticmethod
-    def listdir(dirpath):
+    def listdir(dirpath, recursive=True):
         raise NotImplementedError
 
     @staticmethod

--- a/grow/pods/storage/file_storage.py
+++ b/grow/pods/storage/file_storage.py
@@ -33,12 +33,15 @@ class FileStorage(base_storage.BaseStorage):
         return os.stat(filename)
 
     @staticmethod
-    def listdir(dirpath):
+    def listdir(dirpath, recursive=True):
         paths = []
-        for root, _, files in os.walk(dirpath, followlinks=True):
+        for root, _, files in os.walk(dirpath, topdown=True, followlinks=True):
             for filename in files:
                 path = os.path.join(root, filename)[len(dirpath):]
                 paths.append(path)
+            # if not recursive, break after walking top-level dir
+            if not recursive:
+                break
         return paths
 
     @staticmethod

--- a/grow/pods/storage/google_storage.py
+++ b/grow/pods/storage/google_storage.py
@@ -47,14 +47,15 @@ class CloudStorage(base_storage.BaseStorage):
             raise IOError('File {} not found.'.format(filename))
 
     @staticmethod
-    def listdir(filename):
+    def listdir(filename, recursive=True):
         bucket, prefix = filename[1:].split('/', 1)
         bucket = '/' + bucket
         names = set()
         for item in cloudstorage.listbucket(bucket, prefix=prefix):
             name = item.filename[len(bucket) + len(prefix) + 1:]
             if name:
-                names.add(name)
+                if recursive or '/' not in name:
+                    names.add(name)
         return list(names)
 
     @staticmethod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/globals.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/globals.yaml
@@ -1,0 +1,1 @@
+foo@: YAML in content dir root in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/_blueprint.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/_blueprint.yaml
@@ -1,0 +1,3 @@
+localization:
+  locales:
+  - fr

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc.csv
@@ -1,0 +1,2 @@
+"foo@","bar"
+"CSV in localized collection in localized pod",""

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc.csv
@@ -1,2 +1,2 @@
 "foo@","bar"
-"CSV in localized collection in localized pod",""
+"CSV in localized collection in localized pöd",""

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.html
@@ -3,11 +3,19 @@ $localization:
   locales:
   - it
   - ja
-foo@: Localized base doc front matter in localized collection in localized pod
+  - sv
+foo@: Localized base doc front matter in localized collection in localized pöd
 ---
-{{_('Localized multipart doc base part body in localized collection in localized pod')}}
+{{_('Localized multipart doc base part body in localized collection in localized pöd')}}
 ---
 $locale: ja
-foo@: Localized doc part front matter in localized doc in localized collection in localized pod
+foo@: Localized doc part front matter in localized doc in localized collection in localized pöd
 ---
-{{_('Localized doc part body in localized doc in localized collection in localized pod')}}
+{{_('Localized doc part body in localized doc in localized collection in localized pöd')}}
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale doc part front matter in localized doc in localized collection in localized pöd
+---
+{{_('Multi-locale doc part body in localized doc in localized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.html
@@ -1,0 +1,13 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+foo@: Localized base doc front matter in localized collection in localized pod
+---
+{{_('Localized multipart doc base part body in localized collection in localized pod')}}
+---
+$locale: ja
+foo@: Localized doc part front matter in localized doc in localized collection in localized pod
+---
+{{_('Localized doc part body in localized doc in localized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.yaml
@@ -3,6 +3,12 @@ $localization:
   locales:
   - it
   - ja
+  - sv
 ---
 $locale: ja
-foo@: Localized yaml doc part in localized doc in localized collection in localized pod
+foo@: Localized yaml doc part in localized doc in localized collection in localized pöd
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale yaml doc part in localized doc in localized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/doc_in_parts.yaml
@@ -1,0 +1,8 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+---
+$locale: ja
+foo@: Localized yaml doc part in localized doc in localized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.html
@@ -2,6 +2,6 @@
 $localization:
   locales:
   - it
-foo@: Localized doc front matter in localized collection in localized pod
+foo@: Localized doc front matter in localized collection in localized pöd
 ---
-{{_('Localized doc in localized collection in localized pod')}}
+{{_('Localized doc in localized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.html
@@ -1,0 +1,7 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized doc front matter in localized collection in localized pod
+---
+{{_('Localized doc in localized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.md
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.md
@@ -1,0 +1,6 @@
+---
+$localization:
+  locales:
+  - it
+---
+{{_('Untranslatable MD doc body')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.yaml
@@ -1,4 +1,4 @@
 $localization:
   locales:
   - it
-foo@: Localized yaml doc in localized collection in localized pod
+foo@: Localized yaml doc in localized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/localized_doc.yaml
@@ -1,0 +1,4 @@
+$localization:
+  locales:
+  - it
+foo@: Localized yaml doc in localized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.html
@@ -1,4 +1,4 @@
 ---
-foo@: Unlocalized doc front matter in localized collection in localized pod
+foo@: Unlocalized doc front matter in localized collection in localized pöd
 ---
-{{_('Unlocalized doc body in localized collection in localized pod')}}
+{{_('Unlocalized doc body in localized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.html
@@ -1,0 +1,4 @@
+---
+foo@: Unlocalized doc front matter in localized collection in localized pod
+---
+{{_('Unlocalized doc body in localized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.yaml
@@ -1,1 +1,1 @@
-foo@: Unlocalized yaml doc in localized collection in localized pod
+foo@: Unlocalized yaml doc in localized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc.yaml
@@ -1,0 +1,1 @@
+foo@: Unlocalized yaml doc in localized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc_with_localized_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/localized_collection/unlocalized_doc_with_localized_parts.yaml
@@ -1,0 +1,5 @@
+---
+foo@: Unlocalized base doc part in localized collection in localized pöd
+---
+$locale: ja
+foo@: Localized doc part in unlocalized doc in localized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/_blueprint.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/_blueprint.yaml
@@ -1,0 +1,2 @@
+localization:
+  use_podspec_locales: true

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc.csv
@@ -1,2 +1,2 @@
 "foo@","bar"
-"CSV in unlocalized collection in localized pod",""
+"CSV in unlocalized collection in localized pöd",""

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc.csv
@@ -1,0 +1,2 @@
+"foo@","bar"
+"CSV in unlocalized collection in localized pod",""

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.html
@@ -3,11 +3,19 @@ $localization:
   locales:
   - it
   - ja
-foo@: Localized base doc front matter in unlocalized collection in localized pod
+  - sv
+foo@: Localized base doc front matter in unlocalized collection in localized pöd
 ---
-{{_('Localized multipart doc base part body in unlocalized collection in localized pod')}}
+{{_('Localized multipart doc base part body in unlocalized collection in localized pöd')}}
 ---
 $locale: ja
-foo@: Localized doc part front matter in localized doc in unlocalized collection in localized pod
+foo@: Localized doc part front matter in localized doc in unlocalized collection in localized pöd
 ---
-{{_('Localized doc part body in localized doc in unlocalized collection in localized pod')}}
+{{_('Localized doc part body in localized doc in unlocalized collection in localized pöd')}}
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale doc part front matter in localized doc in unlocalized collection in localized pöd
+---
+{{_('Multi-locale doc part body in localized doc in unlocalized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.html
@@ -1,0 +1,13 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+foo@: Localized base doc front matter in unlocalized collection in localized pod
+---
+{{_('Localized multipart doc base part body in unlocalized collection in localized pod')}}
+---
+$locale: ja
+foo@: Localized doc part front matter in localized doc in unlocalized collection in localized pod
+---
+{{_('Localized doc part body in localized doc in unlocalized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.yaml
@@ -1,0 +1,8 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+---
+$locale: ja
+foo@: Localized yaml doc part in localized doc in unlocalized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/doc_in_parts.yaml
@@ -3,6 +3,12 @@ $localization:
   locales:
   - it
   - ja
+  - sv
 ---
 $locale: ja
-foo@: Localized yaml doc part in localized doc in unlocalized collection in localized pod
+foo@: Localized yaml doc part in localized doc in unlocalized collection in localized pöd
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale yaml doc part in localized doc in unlocalized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.html
@@ -1,0 +1,7 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized doc front matter in unlocalized collection in localized pod
+---
+{{_('Localized doc in unlocalized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.html
@@ -2,6 +2,6 @@
 $localization:
   locales:
   - it
-foo@: Localized doc front matter in unlocalized collection in localized pod
+foo@: Localized doc front matter in unlocalized collection in localized pöd
 ---
-{{_('Localized doc in unlocalized collection in localized pod')}}
+{{_('Localized doc in unlocalized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.md
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.md
@@ -1,0 +1,6 @@
+---
+$localization:
+  locales:
+  - it
+---
+{{_('Untranslatable MD doc body')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.yaml
@@ -1,0 +1,5 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized yaml doc in unlocalized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/localized_doc.yaml
@@ -2,4 +2,4 @@
 $localization:
   locales:
   - it
-foo@: Localized yaml doc in unlocalized collection in localized pod
+foo@: Localized yaml doc in unlocalized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.html
@@ -1,0 +1,4 @@
+---
+foo@: Unlocalized doc front matter in unlocalized collection in localized pod
+---
+{{_('Unlocalized doc body in unlocalized collection in localized pod')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.html
@@ -1,4 +1,4 @@
 ---
-foo@: Unlocalized doc front matter in unlocalized collection in localized pod
+foo@: Unlocalized doc front matter in unlocalized collection in localized pöd
 ---
-{{_('Unlocalized doc body in unlocalized collection in localized pod')}}
+{{_('Unlocalized doc body in unlocalized collection in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.yaml
@@ -1,0 +1,1 @@
+foo@: Unlocalized yaml doc in unlocalized collection in localized pod

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc.yaml
@@ -1,1 +1,1 @@
-foo@: Unlocalized yaml doc in unlocalized collection in localized pod
+foo@: Unlocalized yaml doc in unlocalized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc_with_localized_parts.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/content/unlocalized_collection/unlocalized_doc_with_localized_parts.yaml
@@ -1,0 +1,5 @@
+---
+foo@: Unlocalized base doc part in unlocalized collection in localized pöd
+---
+$locale: ja
+foo@: Localized doc part in unlocalized doc in unlocalized collection in localized pöd

--- a/grow/testing/testdata/extract_localized/localized_pod/podspec.yaml
+++ b/grow/testing/testdata/extract_localized/localized_pod/podspec.yaml
@@ -1,0 +1,4 @@
+localization:
+  locales:
+  - de
+foo@: Localized podspec

--- a/grow/testing/testdata/extract_localized/localized_pod/translations/fr/LC_MESSAGES/messages.po
+++ b/grow/testing/testdata/extract_localized/localized_pod/translations/fr/LC_MESSAGES/messages.po
@@ -1,0 +1,2 @@
+msgid "Existing message in localized pöd"
+msgstr "Existing FR translation in localized pöd"

--- a/grow/testing/testdata/extract_localized/localized_pod/views/includes/header.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/views/includes/header.html
@@ -1,0 +1,1 @@
+{{_('Template in subdir in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/views/template.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/views/template.html
@@ -1,1 +1,1 @@
-{{_('Template in localized pod')}}
+{{_('Template in localized pöd')}}

--- a/grow/testing/testdata/extract_localized/localized_pod/views/template.html
+++ b/grow/testing/testdata/extract_localized/localized_pod/views/template.html
@@ -1,0 +1,1 @@
+{{_('Template in localized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/globals.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/globals.yaml
@@ -1,0 +1,1 @@
+foo@: YAML in content dir root in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/_blueprint.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/_blueprint.yaml
@@ -1,0 +1,3 @@
+localization:
+  locales:
+  - fr

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc.csv
@@ -1,2 +1,2 @@
 "foo@","bar"
-"CSV in localized collection in unlocalized pod",""
+"CSV in localized collection in unlocalized pöd",""

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc.csv
@@ -1,0 +1,2 @@
+"foo@","bar"
+"CSV in localized collection in unlocalized pod",""

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.html
@@ -3,11 +3,19 @@ $localization:
   locales:
   - it
   - ja
-foo@: Localized base doc front matter in localized collection in unlocalized pod
+  - sv
+foo@: Localized base doc front matter in localized collection in unlocalized pöd
 ---
-{{_('Localized multipart doc base part body in localized collection in unlocalized pod')}}
+{{_('Localized multipart doc base part body in localized collection in unlocalized pöd')}}
 ---
 $locale: ja
-foo@: Localized doc part front matter in localized doc in localized collection in unlocalized pod
+foo@: Localized doc part front matter in localized doc in localized collection in unlocalized pöd
 ---
-{{_('Localized doc part body in localized doc in localized collection in unlocalized pod')}}
+{{_('Localized doc part body in localized doc in localized collection in unlocalized pöd')}}
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale doc part front matter in localized doc in localized collection in unlocalized pöd
+---
+{{_('Multi-locale doc part body in localized doc in localized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.html
@@ -1,0 +1,13 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+foo@: Localized base doc front matter in localized collection in unlocalized pod
+---
+{{_('Localized multipart doc base part body in localized collection in unlocalized pod')}}
+---
+$locale: ja
+foo@: Localized doc part front matter in localized doc in localized collection in unlocalized pod
+---
+{{_('Localized doc part body in localized doc in localized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.yaml
@@ -1,0 +1,8 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+---
+$locale: ja
+foo@: Localized yaml doc part in localized doc in localized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/doc_in_parts.yaml
@@ -3,6 +3,12 @@ $localization:
   locales:
   - it
   - ja
+  - sv
 ---
 $locale: ja
-foo@: Localized yaml doc part in localized doc in localized collection in unlocalized pod
+foo@: Localized yaml doc part in localized doc in localized collection in unlocalized pöd
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale yaml doc part in localized doc in localized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.html
@@ -1,0 +1,7 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized doc front matter in localized collection in unlocalized pod
+---
+{{_('Localized doc in localized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.html
@@ -2,6 +2,6 @@
 $localization:
   locales:
   - it
-foo@: Localized doc front matter in localized collection in unlocalized pod
+foo@: Localized doc front matter in localized collection in unlocalized pöd
 ---
-{{_('Localized doc in localized collection in unlocalized pod')}}
+{{_('Localized doc in localized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.md
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.md
@@ -1,0 +1,6 @@
+---
+$localization:
+  locales:
+  - it
+---
+{{_('Untranslatable MD doc body')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.yaml
@@ -2,4 +2,4 @@
 $localization:
   locales:
   - it
-foo@: Localized yaml doc in localized collection in unlocalized pod
+foo@: Localized yaml doc in localized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/localized_doc.yaml
@@ -1,0 +1,5 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized yaml doc in localized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.html
@@ -1,0 +1,4 @@
+---
+foo@: Unlocalized doc front matter in localized collection in unlocalized pod
+---
+{{_('Unlocalized doc body in localized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.html
@@ -1,4 +1,4 @@
 ---
-foo@: Unlocalized doc front matter in localized collection in unlocalized pod
+foo@: Unlocalized doc front matter in localized collection in unlocalized pöd
 ---
-{{_('Unlocalized doc body in localized collection in unlocalized pod')}}
+{{_('Unlocalized doc body in localized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.yaml
@@ -1,1 +1,1 @@
-foo@: Unlocalized yaml doc in localized collection in unlocalized pod
+foo@: Unlocalized yaml doc in localized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc.yaml
@@ -1,0 +1,1 @@
+foo@: Unlocalized yaml doc in localized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc_with_localized_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/localized_collection/unlocalized_doc_with_localized_parts.yaml
@@ -1,0 +1,5 @@
+---
+foo@: Unlocalized base doc part in localized collection in unlocalized pöd
+---
+$locale: ja
+foo@: Localized doc part in unlocalized doc in localized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/_blueprint.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/_blueprint.yaml
@@ -1,0 +1,2 @@
+localization:
+  use_podspec_locales: true

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc.csv
@@ -1,0 +1,2 @@
+"foo@","bar"
+"CSV in unlocalized collection in unlocalized pod",""

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc.csv
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc.csv
@@ -1,2 +1,2 @@
 "foo@","bar"
-"CSV in unlocalized collection in unlocalized pod",""
+"CSV in unlocalized collection in unlocalized pöd",""

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.html
@@ -3,11 +3,19 @@ $localization:
   locales:
   - it
   - ja
-foo@: Localized base doc front matter in unlocalized collection in unlocalized pod
+  - sv
+foo@: Localized base doc front matter in unlocalized collection in unlocalized pöd
 ---
-{{_('Localized multipart doc base part body in unlocalized collection in unlocalized pod')}}
+{{_('Localized multipart doc base part body in unlocalized collection in unlocalized pöd')}}
 ---
 $locale: ja
-foo@: Localized doc part front matter in localized doc in unlocalized collection in unlocalized pod
+foo@: Localized doc part front matter in localized doc in unlocalized collection in unlocalized pöd
 ---
-{{_('Localized doc part body in localized doc in unlocalized collection in unlocalized pod')}}
+{{_('Localized doc part body in localized doc in unlocalized collection in unlocalized pöd')}}
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale doc part front matter in localized doc in unlocalized collection in unlocalized pöd
+---
+{{_('Multi-locale doc part body in localized doc in unlocalized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.html
@@ -1,0 +1,13 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+foo@: Localized base doc front matter in unlocalized collection in unlocalized pod
+---
+{{_('Localized multipart doc base part body in unlocalized collection in unlocalized pod')}}
+---
+$locale: ja
+foo@: Localized doc part front matter in localized doc in unlocalized collection in unlocalized pod
+---
+{{_('Localized doc part body in localized doc in unlocalized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.yaml
@@ -1,0 +1,8 @@
+---
+$localization:
+  locales:
+  - it
+  - ja
+---
+$locale: ja
+foo@: Localized yaml doc part in localized doc in unlocalized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/doc_in_parts.yaml
@@ -3,6 +3,12 @@ $localization:
   locales:
   - it
   - ja
+  - sv
 ---
 $locale: ja
-foo@: Localized yaml doc part in localized doc in unlocalized collection in unlocalized pod
+foo@: Localized yaml doc part in localized doc in unlocalized collection in unlocalized pöd
+---
+$locales:
+- it
+- sv
+foo@: Multi-locale yaml doc part in localized doc in unlocalized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.html
@@ -2,6 +2,6 @@
 $localization:
   locales:
   - it
-foo@: Localized doc front matter in unlocalized collection in unlocalized pod
+foo@: Localized doc front matter in unlocalized collection in unlocalized pöd
 ---
-{{_('Localized doc in unlocalized collection in unlocalized pod')}}
+{{_('Localized doc in unlocalized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.html
@@ -1,0 +1,7 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized doc front matter in unlocalized collection in unlocalized pod
+---
+{{_('Localized doc in unlocalized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.md
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.md
@@ -1,0 +1,6 @@
+---
+$localization:
+  locales:
+  - it
+---
+{{_('Untranslatable MD doc body')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.yaml
@@ -2,4 +2,4 @@
 $localization:
   locales:
   - it
-foo@: Localized yaml doc in unlocalized collection in unlocalized pod
+foo@: Localized yaml doc in unlocalized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/localized_doc.yaml
@@ -1,0 +1,5 @@
+---
+$localization:
+  locales:
+  - it
+foo@: Localized yaml doc in unlocalized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.html
@@ -1,0 +1,4 @@
+---
+foo@: Unlocalized doc front matter in unlocalized collection in unlocalized pod
+---
+{{_('Unlocalized doc body in unlocalized collection in unlocalized pod')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.html
@@ -1,4 +1,4 @@
 ---
-foo@: Unlocalized doc front matter in unlocalized collection in unlocalized pod
+foo@: Unlocalized doc front matter in unlocalized collection in unlocalized pöd
 ---
-{{_('Unlocalized doc body in unlocalized collection in unlocalized pod')}}
+{{_('Unlocalized doc body in unlocalized collection in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.yaml
@@ -1,0 +1,1 @@
+foo@: Unlocalized yaml doc in unlocalized collection in unlocalized pod

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc.yaml
@@ -1,1 +1,1 @@
-foo@: Unlocalized yaml doc in unlocalized collection in unlocalized pod
+foo@: Unlocalized yaml doc in unlocalized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc_with_localized_parts.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/content/unlocalized_collection/unlocalized_doc_with_localized_parts.yaml
@@ -1,0 +1,5 @@
+---
+foo@: Unlocalized base doc part in unlocalized collection in unlocalized pöd
+---
+$locale: ja
+foo@: Localized doc part in unlocalized doc in unlocalized collection in unlocalized pöd

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/podspec.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/podspec.yaml
@@ -1,1 +1,1 @@
-foo@: Unlocalized podspec
+foo@: Unlocalized pödspec

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/podspec.yaml
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/podspec.yaml
@@ -1,0 +1,1 @@
+foo@: Unlocalized podspec

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/views/includes/header.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/views/includes/header.html
@@ -1,0 +1,1 @@
+{{_('Template in subdir in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/views/template.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/views/template.html
@@ -1,1 +1,1 @@
-{{_('Template in unlocalized pod')}}
+{{_('Template in unlocalized pöd')}}

--- a/grow/testing/testdata/extract_localized/unlocalized_pod/views/template.html
+++ b/grow/testing/testdata/extract_localized/unlocalized_pod/views/template.html
@@ -1,0 +1,1 @@
+{{_('Template in unlocalized pod')}}

--- a/grow/testing/testdata/pod/extensions/triplicate.py
+++ b/grow/testing/testdata/pod/extensions/triplicate.py
@@ -1,4 +1,4 @@
-""" Example (but pointless) custom Jinja Extension """
+"""Example (but pointless) custom Jinja Extension."""
 from jinja2.ext import Extension
 
 

--- a/grow/testing/testing.py
+++ b/grow/testing/testing.py
@@ -7,17 +7,17 @@ _here = os.path.dirname(__file__)
 TESTDATA_DIR = os.path.abspath(os.path.join(_here, 'testdata'))
 
 
-# pod_dir is relative to testdata/ dir
-def create_test_pod_dir(pod_dir='pod'):
+# root is relative to testdata/ dir
+def create_test_pod_dir(root='pod'):
     dest_dir = tempfile.mkdtemp()
     dest_dir = os.path.join(dest_dir, 'test_pod')
-    source_dir = os.path.join(TESTDATA_DIR, pod_dir)
+    source_dir = os.path.join(TESTDATA_DIR, root)
     shutil.copytree(source_dir, dest_dir)
     return dest_dir
 
 
-def create_test_pod(pod_dir='pod'):
-    return pods.Pod(create_test_pod_dir(pod_dir))
+def create_test_pod(root='pod'):
+    return pods.Pod(create_test_pod_dir(root))
 
 
 def get_testdata_dir():

--- a/grow/testing/testing.py
+++ b/grow/testing/testing.py
@@ -7,16 +7,17 @@ _here = os.path.dirname(__file__)
 TESTDATA_DIR = os.path.abspath(os.path.join(_here, 'testdata'))
 
 
-def create_test_pod_dir():
+# pod_dir is relative to testdata/ dir
+def create_test_pod_dir(pod_dir='pod'):
     dest_dir = tempfile.mkdtemp()
     dest_dir = os.path.join(dest_dir, 'test_pod')
-    source_dir = os.path.join(TESTDATA_DIR, 'pod')
+    source_dir = os.path.join(TESTDATA_DIR, pod_dir)
     shutil.copytree(source_dir, dest_dir)
     return dest_dir
 
 
-def create_test_pod():
-    return pods.Pod(create_test_pod_dir())
+def create_test_pod(pod_dir='pod'):
+    return pods.Pod(create_test_pod_dir(pod_dir))
 
 
 def get_testdata_dir():


### PR DESCRIPTION
Fixes #204, #157 & #206.

Pretty much by definition this is a breaking change — see #204 and the aim & the included tests for details of cases I’ve covered. Not sure the best way to communicate this to users.

Note that in this version `/data/` **isn’t** treated as a special directory anymore.

I’ve tested this on a very large project I work on and it does what I’d expect:
- Removes unnecessary translations (because of #157)
- No longer extracts tagged terms in ‘global’ locations (i.e. where no document part, document or collection locale can be determined) for all locales defined in the pod: just for those locales in podspec.yaml

This last point caused some work for us: we had a “globals.yaml” file which assumed everything was relevant to _every_ locale (which was wrong: not every locale used those) and hence didn’t declare any locales… which worked until now. Solved by either listing all relevant locales in that file, or listing them all in podspec.yaml (the list there only contained _primary_ locales, which might be better defined at collection level).

**Note:** Would appreciate if people could test on some other projects.

I’ll try a few others of ours while @jeremydw is checking out the code.