### PR TITLE
Fork gcs-oauth2-boto-plugin temporarily to minimize build.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ certifi==1.0.0
 click==4.0
 contentful.py==0.9.3
 dulwich==0.13.0
-gcs-oauth2-boto-plugin==1.14
+gcs-oauth2-boto-plugin-grow==1.14
 google-api-python-client==1.3.1
 goslate==1.4.0
 html2text==2015.6.21

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='Grow SDK Authors',
     author_email='code@grow.io',
     include_package_data=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=['lib*']),
     install_requires=[str(ir.req) for ir in _install_requirements],
     scripts=[
         'bin/grow',


### PR DESCRIPTION
- Exclude any local `lib` from packages.