### PR TITLE
Allow document-level sitemap controls

### DIFF
--- a/grow/pods/sitemap_test.py
+++ b/grow/pods/sitemap_test.py
@@ -15,6 +15,32 @@ class SitemapTest(unittest.TestCase):
         controller = sitemap.SitemapController(pod=self.pod)
         controller.render()
 
+    def test_sitemap_enabled(self):
+        pod = testing.create_pod()
+        pod.write_yaml('/podspec.yaml', {
+            'sitemap': {
+                'enabled': True,
+            },
+        })
+        pod.write_yaml('/content/pages/_blueprint.yaml', {
+            '$path': '/{base}/',
+            '$view': '/views/base.html',
+        })
+        pod.write_yaml('/content/pages/foo.yaml', {
+            '$title': 'Foo',
+        })
+        pod.write_yaml('/content/pages/bar.yaml', {
+            '$title': 'Bar',
+            '$sitemap': {
+                'enabled': False,
+            },
+        })
+        controller, params = pod.match('/sitemap.xml')
+        content = controller.render(params)
+        # Verify $sitemap:enabled = false.
+        self.assertIn('/foo/', content)
+        self.assertNotIn('/bar/', content)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/grow/pods/templates/sitemap.xml
+++ b/grow/pods/templates/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for doc in docs %}
+  {% for doc in docs if not doc.sitemap.enabled is sameas false %}
   <url>
     <loc>{{doc.url}}</loc>
     {% if doc.modified %}


### PR DESCRIPTION
Thanks @stucox -- here's a feature that lets you use `$sitemap: enabled: false` on documents to disable inclusion in the sitemap.

As an FYI, it's not `$sitemap: false` since you can specify other things like `$sitemap.changefreq` and `$sitemap.priority`, plus `$sitemap: enabled: true` is consistent with `sitemap: enabled: true` in the podspec. Let me know if you think we should overload `$sitemap` though.

Fixes https://github.com/grow/grow/issues/258