### PR TITLE
Simplify and test localization fallback

### DIFF
--- a/grow/pods/collection.py
+++ b/grow/pods/collection.py
@@ -287,13 +287,10 @@ class Collection(object):
 
     @utils.cached_property
     def locales(self):
-        # Require $localization in blueprint for localization.
-        if self.localization is not None:
-            if 'locales' in self.localization:
-                identifiers = self.localization['locales'] or []
-                return locales.Locale.parse_codes(identifiers)
-            return self.pod.list_locales()
-        return []
+        if self.localization and 'locales' in self.localization:
+            codes = self.localization['locales'] or []
+            return locales.Locale.parse_codes(codes)
+        return self.pod.list_locales()
 
     def to_message(self):
         message = messages.CollectionMessage()

--- a/grow/pods/collection.py
+++ b/grow/pods/collection.py
@@ -287,20 +287,12 @@ class Collection(object):
 
     @utils.cached_property
     def locales(self):
-        if self.localization:
-            if self.localization.get('use_podspec_locales'):
-                return self.pod.list_locales()
-            try:
-                return locales.Locale.parse_codes(self.localization['locales'])
-            except KeyError:
-                # Locales inherited from podspec.
-                podspec = self.pod.get_podspec()
-                config = podspec.get_config()
-                if ('localization' in config
-                        and 'locales' in config['localization']):
-                    identifiers = config['localization']['locales']
-                    return locales.Locale.parse_codes(identifiers)
-                raise NoLocalesError('{} has no locales.')
+        # Require $localization in blueprint for localization.
+        if self.localization is not None:
+            if 'locales' in self.localization:
+                identifiers = self.localization['locales'] or []
+                return locales.Locale.parse_codes(identifiers)
+            return self.pod.list_locales()
         return []
 
     def to_message(self):

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -26,10 +26,6 @@ class DocumentExistsError(Error, ValueError):
     pass
 
 
-class BadLocalesError(Error, ValueError):
-    pass
-
-
 class Document(object):
 
     def __init__(self, pod_path, _pod, locale=None, _collection=None):
@@ -181,7 +177,6 @@ class Document(object):
     def path_format(self):
         val = None
         if (self.locale
-            and self.default_locale
             and self.locale != self.default_locale):
             if ('$localization' in self.fields
                 and 'path' in self.fields['$localization']):
@@ -286,19 +281,11 @@ class Document(object):
 
     @utils.cached_property
     def locales(self):
+        # Use $localization:locales if present, else use collection's locales.
         localized = '$localization' in self.fields
         if localized and 'locales' in self.fields['$localization']:
-            codes = self.fields['$localization']['locales']
-            if codes is None:
-                return []
+            codes = self.fields['$localization']['locales'] or []
             return locales.Locale.parse_codes(codes)
-        if self.format.has_localized_parts:
-            document_codes = self.format._locales_from_parts
-            diff = set(document_codes) - set(self.collection.locales)
-            if diff:
-                text = '{} specified content for unconfigured locales: {}'
-                text = text.format(self, diff)
-                raise BadLocalesError(text)
         return self.collection.locales
 
     @property

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -425,7 +425,7 @@ class DocumentsTestCase(unittest.TestCase):
         self.assertEqual('/{base}/', de_doc.path_format)
         self.assertEqual('/page/', de_doc.url.path)
 
-        # Override localized collection with "$localization:locales:[]".
+        # Override collection with "$localization:locales:[]" in doc.
         pod.write_yaml('/content/pages/page.yaml', {
             '$localization': {
                 'locales': [],
@@ -433,6 +433,39 @@ class DocumentsTestCase(unittest.TestCase):
         })
         doc = pod.get_doc('/content/pages/page.yaml')
         self.assertEqual([], doc.locales)
+
+        # Override podspec with "$localization:locales:[]" in blueprint.
+        pod = testing.create_pod()
+        pod.write_yaml('/podspec.yaml', {
+            'localization': {
+                'locales': [
+                    'de',
+                ],
+            }
+        })
+        pod.write_yaml('/content/pages/_blueprint.yaml', {
+            '$path': '/{base}/',
+            '$localization': {
+                'locales': [],
+            },
+        })
+        pod.write_yaml('/content/pages/page.yaml', {})
+        doc = pod.get_doc('/content/pages/page.yaml')
+        collection = pod.get_collection('/content/pages/')
+        self.assertEqual([], collection.locales)
+        self.assertEqual([], doc.locales)
+
+        # Override the overridden podspec.
+        pod.write_yaml('/content/pages/page.yaml', {
+            '$localization': {
+                'locales': [
+                    'de',
+                    'ja',
+                ],
+            },
+        })
+        doc = pod.get_doc('/content/pages/page.yaml')
+        self.assertEqual(['de', 'ja'], doc.locales)
 
 
 if __name__ == '__main__':

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -376,9 +376,9 @@ class DocumentsTestCase(unittest.TestCase):
             '$path': '/{base}/',
         })
         collection = pod.get_collection('/content/pages/')
-        self.assertEqual([], collection.locales)
+        self.assertEqual(['de'], collection.locales)
         doc = pod.get_doc('/content/pages/page.yaml')
-        self.assertEqual([], doc.locales)
+        self.assertEqual(['de'], doc.locales)
 
         # Localized podspec ($localization in blueprint).
         pod = testing.create_pod()
@@ -416,7 +416,6 @@ class DocumentsTestCase(unittest.TestCase):
         })
         pod.write_yaml('/content/pages/_blueprint.yaml', {
             '$path': '/{base}/',
-            '$localization': {},
         })
         pod.write_yaml('/content/pages/page.yaml', {})
         doc = pod.get_doc('/content/pages/page.yaml')

--- a/grow/pods/formats.py
+++ b/grow/pods/formats.py
@@ -28,6 +28,10 @@ class BadFormatError(Error, ValueError):
     pass
 
 
+class BadLocalesError(BadFormatError):
+    pass
+
+
 class Format(object):
 
     def __init__(self, doc):
@@ -162,7 +166,7 @@ class _SplitDocumentFormat(Format):
     def _validate_fields(self, fields):
         if '$locale' in fields and '$locales' in fields:
             text = 'You must specify either $locale or $locales, not both.'
-            raise BadFormatError(text)
+            raise BadLocalesError(text)
 
     def _validate_base_part(self, fields):
         self._validate_fields(fields)
@@ -172,12 +176,7 @@ class _SplitDocumentFormat(Format):
         # (otherwise there's no point)
         if '$locale' not in fields and '$locales' not in fields:
             text = 'You must specify either $locale or $locales for each document part.'
-            raise BadFormatError(text)
-        invalid_locales = set(self._locales_from_parts) - set(self._locales_from_base + self.doc.collection.locales)
-        if invalid_locales:
-            text = ('You must specify $locales in either the base '
-                    'part of the document or in the blueprint.')
-            raise BadFormatError(text)
+            raise BadLocalesError(text)
         self._validate_fields(fields)
 
     def _get_locales_of_part(self, fields):
@@ -190,6 +189,7 @@ class _SplitDocumentFormat(Format):
         if '$localization' in fields:
             if 'default_locale' in fields['$localization']:
                 return fields['$localization']['default_locale']
+        return self.doc.collection.default_locale
 
     def _load_yaml(self, part):
         try:

--- a/grow/testing/testdata/pod/content/posts/_blueprint.yaml
+++ b/grow/testing/testdata/pod/content/posts/_blueprint.yaml
@@ -1,5 +1,7 @@
 path: /post/{base}/
 view: /views/posts.html
+localization:
+  locales: []
 
 fields:
 


### PR DESCRIPTION
Simplify localization fallback between documents, collections, podspec; remove validation as it does not account for sub-collections without blueprints, add extensive test coverage for all the ways one could localize (or disable localization of) documents.

This PR:
- *Removes* the requirement of bueprints to, at a minimum, specify `$localization: {}` in order to opt-in to localization for the entire collection, even if the podspec is localized. This now requires blueprints to set `$localization: locales: []` to disable localization, if it was enabled at the podspec-level. #265 
- Permits documents to be localized, even if blueprints or the podspec aren't, by specifying `$localization:locales` at the document-level. #204 
- Allows one to disable localization for a document by using `$localization: locales: ~`. #214 
- Enables one to override the value of a key in the default locale using `<key>@<default locale>: <value>` without modifying the value of keys in other locales. #180 
- Removes locale validation since I discovered too many cases of sub-folders in collections being used without blueprints in those folders, which is basically undefined behavior. I don't want to break the use of this, so I removed the locale validation. 
- Should add enough test coverage to close #157 

At a high level (this will be documented after this PR is merged), here's how document localization works. This is not really different from practical use cases before, with the exception of defaulting to inheriting the podspec's locales if `$localization` isn't present in a collection but is in the podspec.

1. Uses a document's `$localization:locales` if present.
1. If not present, falls back to the blueprint's `$localization:locales`.
1. If blueprint's `$localization:locales` is not present, use locales from the podspec.

The use of `$localization:locales` -> `[]` or `nil` localization disables localization.

@stucox please take a look when you get a chance, particularly at all the tests in `documents_test.py` since they describe and verify the above notes. Thanks!