### PR TITLE
Remove unsafe install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,7 @@ Grow is a declarative tool for rapidly building, launching, and maintaining high
 
 ## Quick start
 
-Run the commands below to start a server. The install script explains what
-it does and pauses before each action.
-
-```bash
-curl https://install.growsdk.org | bash
-grow init base base
-cd base
-grow run
-```
-
-- [Read quick start documentation](https://grow.io/docs/).
-
-You can alternatively `pip install grow` if you like.
+`pip install grow`
 
 ## Developing Grow itself
 


### PR DESCRIPTION
No one should ever have to pipe anything from curl into bash.... It's unsafe and even if it is considered safe for this project it promotes bad practice.