### PR TITLE
Safer translation

### DIFF
--- a/grow/commands/upload_translations.py
+++ b/grow/commands/upload_translations.py
@@ -18,10 +18,10 @@ import os
 @click.option('--update-acl', default=False, is_flag=True,
               help='Whether to update the ACL on uploaded resources'
                    ' instead of uploading new translation files.')
-@click.option('--download', '-d', default=False, is_flag=True,
+@click.option('--download', '-d', default=True, is_flag=True,
               help='Whether to download any existing translations prior'
                    ' to uploading.')
-@click.option('--extract', '-x', default=False, is_flag=True,
+@click.option('--extract', '-x', default=True, is_flag=True,
               help='Whether to extract translations prior to uploading.')
 def upload_translations(pod_path, locale, force, service, update_acl,
                         download, extract):

--- a/grow/commands/upload_translations.py
+++ b/grow/commands/upload_translations.py
@@ -21,12 +21,23 @@ import os
 @click.option('--download', '-d', default=False, is_flag=True,
               help='Whether to download any existing translations prior'
                    ' to uploading.')
+@click.option('--extract', '-x', default=False, is_flag=True,
+              help='Whether to extract translations prior to uploading.')
 def upload_translations(pod_path, locale, force, service, update_acl,
-                        download):
+                        download, extract):
     """Uploads translations to a translation service."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     pod = pods.Pod(root, storage=storage.FileStorage)
     translator = pod.get_translator(service)
+
+    if extract:
+        include_obsolete, localized, include_header, use_fuzzy_matching, = \
+            pod.catalogs.get_extract_config()
+        catalogs = pod.get_catalogs()
+        catalogs.extract(include_obsolete=include_obsolete, localized=localized,
+                         include_header=include_header,
+                         use_fuzzy_matching=use_fuzzy_matching)
+
     if not translator:
         raise click.ClickException('No translators specified in podspec.yaml.')
     if update_acl:


### PR DESCRIPTION
Updating the `upload_translations` command to be able to `extract` the catalogs before uploading.

Also set the default for the `download` and `extract` commands to be ON to help prevent accidental translation loss.