### PR TITLE
Add support for regexes in locale-override yaml syntax.

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -320,13 +320,8 @@ def untag_fields(fields, locale=None):
             updated_localized_paths.add((path, key))
             return key, value
         untagged_key, locale_from_key = match.groups()
-        if (locale
-                and locale_from_key.startswith('/')
-                and locale_from_key.endswith('/')):
-            locale_regex = locale_from_key[1:-1]
-            if not re.match(locale_regex, locale):
-                return False
-        elif locale_from_key != locale:
+        locale_regex = r'^{}$'.format(locale_from_key)
+        if not locale or not re.match(locale_regex, locale):
             return False
         updated_localized_paths.add((path, untagged_key.rstrip('@')))
         return untagged_key, value

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -34,7 +34,7 @@ except ImportError:
     from yaml import Loader as yaml_Loader
 
 
-LOCALIZED_KEY_REGEX = re.compile('(.*)@([\w|-]+)$')
+LOCALIZED_KEY_REGEX = re.compile('(.*)@([^@]+)$')
 SENTINEL = object()
 SLUG_REGEX = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
 
@@ -320,7 +320,13 @@ def untag_fields(fields, locale=None):
             updated_localized_paths.add((path, key))
             return key, value
         untagged_key, locale_from_key = match.groups()
-        if locale_from_key != locale:
+        if (locale
+                and locale_from_key.startswith('/')
+                and locale_from_key.endswith('/')):
+            locale_regex = locale_from_key[1:-1]
+            if not re.match(locale_regex, locale):
+                return False
+        elif locale_from_key != locale:
             return False
         updated_localized_paths.add((path, untagged_key.rstrip('@')))
         return untagged_key, value

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -381,6 +381,73 @@ class UtilsTestCase(unittest.TestCase):
             },
         }, utils.untag_fields(fields))
 
+    def test_untag_fields_with_regex(self):
+        fields_to_test = {
+            'foo': 'bar-base',
+            'foo@de': 'bar-de',
+            'foo@/fr/': 'bar-fr',
+            'nested': {
+                'nested': 'nested-base',
+                'nested@/fr/': 'nested-fr',
+            },
+        }
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'foo': 'bar-fr',
+            'nested': {
+                'nested': 'nested-fr',
+            },
+        }, utils.untag_fields(fields, locale='fr'))
+        self.assertDictEqual({
+            'foo': 'bar-fr',
+            'nested': {
+                'nested': 'nested-fr',
+            },
+        }, utils.untag_fields(fields, locale='fr_FR'))
+        self.assertDictEqual({
+            'foo': 'bar-fr',
+            'nested': {
+                'nested': 'nested-fr',
+            },
+        }, utils.untag_fields(fields, locale='fr_CA'))
+        self.assertDictEqual({
+            'foo': 'bar-de',
+            'nested': {
+                'nested': 'nested-base',
+            },
+        }, utils.untag_fields(fields, locale='de'))
+
+        fields_to_test = {
+            'foo': 'bar-base',
+            'foo@de': 'bar-de',
+            'foo@/fr|it/': 'bar-any',
+            'nested': {
+                'nested': 'nested-base',
+                'nested@/fr|it/': 'nested-any',
+            },
+        }
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'foo': 'bar-any',
+            'nested': {
+                'nested': 'nested-any',
+            },
+        }, utils.untag_fields(fields, locale='fr'))
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'foo': 'bar-any',
+            'nested': {
+                'nested': 'nested-any',
+            },
+        }, utils.untag_fields(fields, locale='it'))
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'foo': 'bar-de',
+            'nested': {
+                'nested': 'nested-base',
+            },
+        }, utils.untag_fields(fields, locale='de'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -385,10 +385,11 @@ class UtilsTestCase(unittest.TestCase):
         fields_to_test = {
             'foo': 'bar-base',
             'foo@de': 'bar-de',
-            'foo@/fr/': 'bar-fr',
+            'foo@fr.*': 'bar-fr',
             'nested': {
                 'nested': 'nested-base',
-                'nested@/fr/': 'nested-fr',
+                'nested@de_AT': 'nested-de',
+                'nested@fr': 'nested-fr',
             },
         }
         fields = copy.deepcopy(fields_to_test)
@@ -401,13 +402,13 @@ class UtilsTestCase(unittest.TestCase):
         self.assertDictEqual({
             'foo': 'bar-fr',
             'nested': {
-                'nested': 'nested-fr',
+                'nested': 'nested-base',
             },
         }, utils.untag_fields(fields, locale='fr_FR'))
         self.assertDictEqual({
             'foo': 'bar-fr',
             'nested': {
-                'nested': 'nested-fr',
+                'nested': 'nested-base',
             },
         }, utils.untag_fields(fields, locale='fr_CA'))
         self.assertDictEqual({
@@ -416,14 +417,20 @@ class UtilsTestCase(unittest.TestCase):
                 'nested': 'nested-base',
             },
         }, utils.untag_fields(fields, locale='de'))
+        self.assertDictEqual({
+            'foo': 'bar-base',
+            'nested': {
+                'nested': 'nested-de',
+            },
+        }, utils.untag_fields(fields, locale='de_AT'))
 
         fields_to_test = {
             'foo': 'bar-base',
             'foo@de': 'bar-de',
-            'foo@/fr|it/': 'bar-any',
+            'foo@fr|it': 'bar-any',
             'nested': {
                 'nested': 'nested-base',
-                'nested@/fr|it/': 'nested-any',
+                'nested@fr|it': 'nested-any',
             },
         }
         fields = copy.deepcopy(fields_to_test)


### PR DESCRIPTION
Fixes #319 

@stevenle @Zoramite – can you look at this syntax? In practice this seems to work really well and be a good, flexible solution I'm just worried that the following YAML syntax is too verbose. Any thoughts or is it OK?

```
foo@: Base foo.
foo@/de/: Foo for any locale that matches regex `de`.
foo@/it|fr|ca/: Foo for any locale that matches regex `it|fr|ca`.
```