### PR TITLE
Adding the ability to use `none` or no language for the code block.

### DIFF
--- a/grow/common/markdown_extensions.py
+++ b/grow/common/markdown_extensions.py
@@ -128,7 +128,7 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
         src/e79a7126551c39d5f8c1b83a79c14e86992155a4/external/markdown-processor.py
     """
     KIND = 'sourcecode'
-    pattern_tag = re.compile(r'\[sourcecode:(.+?)\](.+?)\[/sourcecode\]', re.S)
+    pattern_tag = re.compile(r'\[sourcecode(:.*?)\](.+?)\[/sourcecode\]', re.S)
     pattern_ticks = re.compile(r'```(.+?)\n(.+?)\n```', re.S)
 
     class Config(messages.Message):
@@ -156,6 +156,9 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
         class_name = self.config.class_name
         def repl(m):
             language = m.group(1)
+            language = language[1:] if language[0] == ':' else language
+            if language in ['', 'none']:
+                language = 'text'
             content = m.group(2)
             if self.config.highlighter == 'pygments':
                 try:

--- a/grow/common/markdown_extensions_test.py
+++ b/grow/common/markdown_extensions_test.py
@@ -98,6 +98,22 @@ class CodeBlockPreprocessorTestCase(unittest.TestCase):
         style_sentinel = 'style="background: #f8f8f8"'
         self.assertIn(style_sentinel, result)
 
+        # Verify no language.
+        content = """
+        [sourcecode]
+        <div class="test">
+          Hello World
+        </div>
+        [/sourcecode]
+        """
+        pod.write_file('/content/pages/test.md', content)
+        content = '{{doc.html|safe}}'
+        pod.write_file('/views/base.html', content)
+        controller, params = pod.match('/test/')
+        result = controller.render(params)
+        style_sentinel = 'style="background: #f8f8f8"'
+        self.assertIn(style_sentinel, result)
+
         # Verify ticks.
         content = textwrap.dedent(
             """


### PR DESCRIPTION
Instead of failing it should now use a default of the 'text' formatting which does not have any coloring.

This makes `[sourcecode:none]` and `[sourcecode]` both valid.

Closes #307
Closes #321