### PR TITLE
Separate the formatting of sheets from the data.

### DIFF
--- a/grow/commands/upload_translations.py
+++ b/grow/commands/upload_translations.py
@@ -29,12 +29,25 @@ import os
                    ' Normally message may be removed and readded periodically'
                    ' so they are not removed, but can be removed to clean up'
                    ' translations but cannot be retrieved once pruned.')
+@click.option('--update-meta', default=False, is_flag=True,
+              help='Whether to update the meta information for the uploaded'
+                   ' resources instead of uploading new translation files.'
+                   ' This updates properties that are not directly related to'
+                   ' the translation data, such as styling or filters')
 def upload_translations(pod_path, locale, force, service, update_acl,
-                        download, extract, prune):
+                        download, extract, prune, update_meta):
     """Uploads translations to a translation service."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     pod = pods.Pod(root, storage=storage.FileStorage)
     translator = pod.get_translator(service)
+
+    if update_acl:
+        translator.update_acl(locales=locale)
+        return
+
+    if update_meta:
+        translator.update_meta(locales=locale)
+        return
 
     if extract:
         include_obsolete, localized, include_header, use_fuzzy_matching, = \
@@ -49,8 +62,6 @@ def upload_translations(pod_path, locale, force, service, update_acl,
 
     if not translator:
         raise click.ClickException('No translators specified in podspec.yaml.')
-    if update_acl:
-        translator.update_acl(locales=locale)
     else:
         # TODO Remove the download from the upload arguments to clean it up.
         translator.upload(locales=locale, force=force, verbose=True,

--- a/grow/commands/upload_translations.py
+++ b/grow/commands/upload_translations.py
@@ -41,6 +41,9 @@ def upload_translations(pod_path, locale, force, service, update_acl,
     pod = pods.Pod(root, storage=storage.FileStorage)
     translator = pod.get_translator(service)
 
+    if not translator:
+        raise click.ClickException('No translators specified in podspec.yaml.')
+
     if update_acl:
         translator.update_acl(locales=locale)
         return
@@ -60,9 +63,6 @@ def upload_translations(pod_path, locale, force, service, update_acl,
         catalogs.update(locales=locales, include_header=include_header,
                         use_fuzzy_matching=use_fuzzy_matching)
 
-    if not translator:
-        raise click.ClickException('No translators specified in podspec.yaml.')
-    else:
-        # TODO Remove the download from the upload arguments to clean it up.
-        translator.upload(locales=locale, force=force, verbose=True,
-                          download=download, prune=prune)
+    # TODO Remove the download from the upload arguments to clean it up.
+    translator.upload(locales=locale, force=force, verbose=True,
+                      download=download, prune=prune)

--- a/grow/translators/google_sheets.py
+++ b/grow/translators/google_sheets.py
@@ -50,13 +50,10 @@ class GoogleSheetsTranslator(base.Translator):
     HEADER_ROW_COUNT = 1
     has_immutable_translation_resources = False
     has_multiple_langs_in_one_resource = True
-    service = None
 
     def _create_service(self):
-        if not self.service:
-            self.service = google_drive.BaseGooglePreprocessor.create_service(
-                    'sheets', 'v4')
-        return self.service
+        return google_drive.BaseGooglePreprocessor.create_service(
+                'sheets', 'v4')
 
     def _download_sheet(self, spreadsheet_id, locale):
         service = self._create_service()
@@ -276,7 +273,7 @@ class GoogleSheetsTranslator(base.Translator):
             _, new_rows, _ = self._diff_data([], catalog)
             row_data = []
             row_data.append(self._create_header_row_data(source_lang, lang))
-            
+
             if len(new_rows):
                 for value in new_rows:
                     row_data.append(self._create_catalog_row(

--- a/grow/translators/google_sheets.py
+++ b/grow/translators/google_sheets.py
@@ -50,9 +50,13 @@ class GoogleSheetsTranslator(base.Translator):
     HEADER_ROW_COUNT = 1
     has_immutable_translation_resources = False
     has_multiple_langs_in_one_resource = True
+    service = None
 
     def _create_service(self):
-        return google_drive.BaseGooglePreprocessor.create_service('sheets', 'v4')
+        if not self.service:
+            self.service = google_drive.BaseGooglePreprocessor.create_service(
+                    'sheets', 'v4')
+        return self.service
 
     def _download_sheet(self, spreadsheet_id, locale):
         service = self._create_service()


### PR DESCRIPTION
Also revamping the way that batch requests are created to make the number of server requests smaller.

The creation of new language sheets is also improved to be created as part of the same batch request as other updates making the creation and update process atomic.

Currently updating the meta (such as styling) is available under the `--update_meta` flag. In the future want to make this process smarter to automatically apply any time a new version of grow is used to upload translations.

Part of #317