### PR TITLE
Fixing having too few columns for uploading translations to Google Sheets

### DIFF
--- a/grow/translators/google_sheets.py
+++ b/grow/translators/google_sheets.py
@@ -48,7 +48,8 @@ class GoogleSheetsTranslator(base.Translator):
     }
     KIND = 'google_sheets'
     HEADER_ROW_COUNT = 1
-    HEADER_LABELS = ['', '', 'Location']
+    # Source locale, translation locale, message location.
+    HEADER_LABELS = [None, None, 'Location']
     has_immutable_translation_resources = False
     has_multiple_langs_in_one_resource = True
 
@@ -72,7 +73,7 @@ class GoogleSheetsTranslator(base.Translator):
         column_count = len(self.HEADER_LABELS)
         if len(resp['values'][0]) < column_count:
             missing_columns = [None] * (column_count - len(resp['values'][0]))
-            resp['values'][:]=[i + missing_columns for i in resp['values']]
+            resp['values'][:] = [i + missing_columns for i in resp['values']]
 
         return resp['values']
 


### PR DESCRIPTION
Older version of the spreadsheet may be missing a column (ex: locations) or using existing spreadsheets may only have the source and translation columns. These changes should enable the upload command to detect when there is missing columns and add them to the sheet and fill in the missing column header.