### PR TITLE
Update to extract behavior for upload_translations

### DIFF
--- a/grow/commands/extract.py
+++ b/grow/commands/extract.py
@@ -48,14 +48,14 @@ def extract(pod_path, init, update, include_obsolete, localized,
         pod.catalogs.get_extract_config(include_header=include_header,
             include_obsolete=include_obsolete, localized=localized,
             use_fuzzy_matching=fuzzy_matching)
+    locales = validate_locales(pod.list_locales(), locale)
     catalogs = pod.get_catalogs()
     catalogs.extract(include_obsolete=include_obsolete, localized=localized,
                      include_header=include_header,
-                     use_fuzzy_matching=use_fuzzy_matching)
+                     use_fuzzy_matching=use_fuzzy_matching, locales=locales)
     if localized:
         return
     if init:
-        locales = validate_locales(pod.list_locales(), locale)
         text = 'Initializing {} empty translation catalogs.'
         pod.logger.info(text.format(len(locales)))
         catalogs.init(locales=locales, include_header=include_header)

--- a/grow/commands/upload_translations.py
+++ b/grow/commands/upload_translations.py
@@ -59,11 +59,12 @@ def upload_translations(pod_path, locale, force, service, update_acl,
         include_obsolete, localized, include_header, use_fuzzy_matching, = \
             pod.catalogs.get_extract_config()
         catalogs = pod.get_catalogs()
+        locales = validate_locales(pod.list_locales(), locale)
         catalogs.extract(include_obsolete=include_obsolete, localized=localized,
                          include_header=include_header,
-                         use_fuzzy_matching=use_fuzzy_matching)
-        locales = validate_locales(pod.list_locales(), locale)
-        catalogs.update(locales=locales, include_header=include_header,
-                        use_fuzzy_matching=use_fuzzy_matching)
+                         use_fuzzy_matching=use_fuzzy_matching, locales=locales)
+        if not localized:
+            catalogs.update(locales=locales, include_header=include_header,
+                            use_fuzzy_matching=use_fuzzy_matching)
 
     translator.upload(locales=locale, force=force, verbose=True, prune=prune)


### PR DESCRIPTION
Make the extract that runs during upload_translations consistent with the extract that runs during download; for localized catalogs.