### PR TITLE
Initial functionality for supporting the dynamic ui tools

### DIFF
--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -117,6 +117,10 @@ class Pod(object):
     def title(self):
         return self.yaml.get('title')
 
+    @property
+    def ui(self):
+        return self.yaml.get('ui')
+
     def match(self, path):
         return self.routes.match(path, env=self.env.to_wsgi_env())
 

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -55,7 +55,8 @@ class RenderedController(controllers.BaseController):
                 'podspec': self.pod.get_podspec(),
             }
             content = template.render(kwargs).lstrip()
-            content = self._inject_ui(content, preprocessor, translator)
+            content = self._inject_ui(
+                content, preprocessor, translator, self.pod.ui)
             return content
         except Exception as e:
             text = 'Error building {}: {}'
@@ -65,7 +66,8 @@ class RenderedController(controllers.BaseController):
             exception.exception = e
             raise exception
 
-    def _inject_ui(self, content, preprocessor, translator):
+    def _inject_ui(self, content, preprocessor, translator, ui_settings):
+        # TODO Enable the ui when the ui option is enabled in deploy settings.
         show_ui = (self.pod.env.name == env.Name.DEV
                    and (preprocessor or translator)
                    and self.get_mimetype().endswith('html'))
@@ -76,5 +78,6 @@ class RenderedController(controllers.BaseController):
                 'doc': self.doc,
                 'preprocessor': preprocessor,
                 'translator': translator,
+                'ui': ui_settings,
             })
         return content

--- a/grow/pods/rendered_test.py
+++ b/grow/pods/rendered_test.py
@@ -122,7 +122,7 @@ class RenderedTest(unittest.TestCase):
 
         # Verify UI injected when preprocessor is present.
         controller, _ = pod.match('/index/')
-        result = controller._inject_ui(content, dummy_preprocessor, dummy_preprocessor)
+        result = controller._inject_ui(content, dummy_preprocessor, dummy_preprocessor, [])
         self.assertIn(ui_sentinel, result)
 
 

--- a/grow/pods/ui.py
+++ b/grow/pods/ui.py
@@ -1,5 +1,6 @@
 from grow.common import utils
 from grow.pods.storage import storage
+from grow.pods import tags
 import jinja2
 import os
 
@@ -8,7 +9,7 @@ import os
 def create_jinja_env():
     root = os.path.join(utils.get_grow_dir(), 'ui', 'templates')
     loader = storage.FileStorage.JinjaLoader(root)
-    return jinja2.Environment(
+    env = jinja2.Environment(
         loader=loader,
         autoescape=True,
         trim_blocks=True,
@@ -19,3 +20,6 @@ def create_jinja_env():
             'jinja2.ext.loopcontrols',
             'jinja2.ext.with_',
         ])
+    env.filters.update(tags.create_builtin_filters())
+
+    return env

--- a/grow/server/main.py
+++ b/grow/server/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import jinja2
+import mimetypes
 import re
 import sys
 import traceback
@@ -76,6 +77,15 @@ def serve_pod(pod, request, values):
     return response
 
 
+def serve_tool(pod, request, values):
+    tool_path = values.get('tool')
+    response = wrappers.Response(pod.read_file(tool_path))
+    guessed_type = mimetypes.guess_type(tool_path)
+    mime_type = guessed_type[0] or 'text/plain'
+    response.headers['Content-Type'] = mime_type
+    return response
+
+
 class PodServer(object):
 
     def __init__(self, pod, debug=False):
@@ -84,6 +94,7 @@ class PodServer(object):
         self.debug = debug
         self.url_map = routing.Map([
             rule('/', endpoint=serve_pod),
+            rule('/_grow/ui/tools/<path:tool>', endpoint=serve_tool),
             rule('/_grow/<any("translations"):page>/<path:locale>', endpoint=serve_console),
             rule('/_grow/<path:page>', endpoint=serve_console),
             rule('/_grow', endpoint=serve_console),

--- a/grow/server/main.py
+++ b/grow/server/main.py
@@ -77,7 +77,7 @@ def serve_pod(pod, request, values):
     return response
 
 
-def serve_tool(pod, request, values):
+def serve_ui_tool(pod, request, values):
     tool_path = values.get('tool')
     response = wrappers.Response(pod.read_file(tool_path))
     guessed_type = mimetypes.guess_type(tool_path)
@@ -94,7 +94,7 @@ class PodServer(object):
         self.debug = debug
         self.url_map = routing.Map([
             rule('/', endpoint=serve_pod),
-            rule('/_grow/ui/tools/<path:tool>', endpoint=serve_tool),
+            rule('/_grow/ui/tools/<path:tool>', endpoint=serve_ui_tool),
             rule('/_grow/<any("translations"):page>/<path:locale>', endpoint=serve_console),
             rule('/_grow/<path:page>', endpoint=serve_console),
             rule('/_grow', endpoint=serve_console),

--- a/grow/ui/js/ui.js
+++ b/grow/ui/js/ui.js
@@ -6,14 +6,12 @@ window.grow = grow;
 
   grow.ui = grow.ui || {};
 
-  grow.ui.showNotice = function(text, className) {
+  grow.ui.showNotice = function(text) {
     var notice = document.createElement('div');
     notice.classList.add('grow_tool__notice');
-    notice.classList.add(className);
     notice.appendChild(document.createTextNode(text));
 
     document.body.appendChild(notice);
-
     return notice;
   };
 

--- a/grow/ui/js/ui.js
+++ b/grow/ui/js/ui.js
@@ -1,8 +1,15 @@
 var grow = grow || {};
-grow.ui = grow.ui || {};
 window.grow = grow;
 
 (function(grow){
+  var toolConfig = {};
+
+  grow.ui = grow.ui || {};
+
+  grow.ui.toolConfig = function(tool, options) {
+    toolConfig[tool] = options;
+  };
+
   grow.ui.tools = grow.ui.tools || [];
   grow.ui.main = function(settings) {
     var el = document.createElement('div');
@@ -31,9 +38,13 @@ window.grow = grow;
         'translate', 'Translate', settings.injectTranslateUrl));
     }
 
-    // TODO: Make the tools configurable.
     for(i in grow.ui.tools) {
       tool = grow.ui.tools[i];
+
+      if (tool['init']) {
+        tool['init'](toolConfig[tool['kind']] || {});
+      }
+
       if (tool['button']) {
         buttonsEl.appendChild(createButton_(
           tool['key'], tool['name'], tool['button']['link'] || null,

--- a/grow/ui/js/ui.js
+++ b/grow/ui/js/ui.js
@@ -6,6 +6,17 @@ window.grow = grow;
 
   grow.ui = grow.ui || {};
 
+  grow.ui.showNotice = function(text, className) {
+    var notice = document.createElement('div');
+    notice.classList.add('grow_tool__notice');
+    notice.classList.add(className);
+    notice.appendChild(document.createTextNode(text));
+
+    document.body.appendChild(notice);
+
+    return notice;
+  };
+
   grow.ui.toolConfig = function(tool, options) {
     toolConfig[tool] = options;
   };

--- a/grow/ui/js/ui.js
+++ b/grow/ui/js/ui.js
@@ -47,7 +47,7 @@ window.grow = grow;
 
       if (tool['button']) {
         buttonsEl.appendChild(createButton_(
-          tool['key'], tool['name'], tool['button']['link'] || null,
+          tool['kind'], tool['name'], tool['button']['link'] || null,
           tool['button']['events'] || {}));
       }
     }

--- a/grow/ui/sass/ui.sass
+++ b/grow/ui/sass/ui.sass
@@ -11,6 +11,8 @@ $transition_medium: 1000ms
 
 #grow-utils
   all: revert
+  font-family: Verdana, Arial, Helvetica, sans-serif
+  font-size: 13px
   z-index: 9999
 
   *

--- a/grow/ui/sass/ui.sass
+++ b/grow/ui/sass/ui.sass
@@ -119,3 +119,19 @@ $transition_medium: 1000ms
     &.grow__expand
       .grow__label
         display: inherit !important
+
+.grow_tool__notice
+  background: $color-primary
+  border-radius: .35em
+  bottom: 2em
+  border: 1px solid rgba(255, 255, 255, .5)
+  box-shadow: 0 0 .5em rgba(0, 0, 0, .5)
+  color: $color-on-primary
+  font-family: Verdana, Arial, Helvetica, sans-serif
+  font-size: 12px
+  line-height: 1.2em
+  left: 2em
+  padding: .5em
+  position: fixed
+  width: 75%
+  z-index: 9999

--- a/grow/ui/templates/ui.html
+++ b/grow/ui/templates/ui.html
@@ -2,6 +2,13 @@
 {% set translator_edit_url = translator and translator.get_edit_url(doc) %}
 <link rel="stylesheet" href="/_grow/ui/css/ui.min.css">
 <script src="/_grow/ui/js/ui.min.js"></script>
+{% for tool in ui.tools %}
+  <link rel="stylesheet" href="/_grow/ui/tools/node_modules/grow-tool-{{tool.kind}}/tool.css">
+  <script src="/_grow/ui/tools/node_modules/grow-tool-{{tool.kind}}/tool.js"></script>
+  {% if tool.options is defined %}
+    <script>grow.ui.toolConfig('{{tool.kind}}', {{tool.options | jsonify | safe}});</script>
+  {% endif %}
+{% endfor %}
 <script>
   grow.ui.main({
     docPodPath: '{{doc.pod_path}}',


### PR DESCRIPTION
Reads the list of tools from the podspec and uses it to include the correct files from the project's `node_modules` directory.

This initial version is very opinionated and targeted towards the usage of npm. Future versions should make this path variable based on configuration in the podspec.

Part of #342