### PR TITLE
Making the files starting with `.` ignored by default in `g.statics`.

### DIFF
--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -191,9 +191,10 @@ class Pod(object):
             return [col for col in cols if col.collection_path in paths]
         return cols
 
-    def list_statics(self, pod_path, locale=None):
+    def list_statics(self, pod_path, locale=None, include_hidden=False):
         for path in self.list_dir(pod_path):
-            yield self.get_static(pod_path + path, locale=locale)
+            if include_hidden or not path.rsplit(os.sep, 1)[-1].startswith('.'):
+                yield self.get_static(pod_path + path, locale=locale)
 
     def get_url(self, pod_path, locale=None):
         if pod_path.startswith('/content'):

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -107,6 +107,7 @@ class PodTest(unittest.TestCase):
             '/public/file.txt',
             '/public/main.css',
             '/public/main.min.js',
+            '/public/dir/file.txt',
             '/root/base/index.html',
             '/root/sitemap.xml',
             '/root/static/file-aa843134a2a113f7ebd5386c4d094a1a.min.js',
@@ -140,6 +141,19 @@ class PodTest(unittest.TestCase):
     def test_list_statics(self):
         items = self.pod.list_statics('/public/')
         expected = [
+            self.pod.get_static('/public/dir/file.txt'),
+            self.pod.get_static('/public/file.txt'),
+            self.pod.get_static('/public/main.css'),
+            self.pod.get_static('/public/main.min.js'),
+        ]
+        for item in items:
+            self.assertIn(item, expected)
+
+    def test_list_statics_hidden(self):
+        items = self.pod.list_statics('/public/', include_hidden=True)
+        expected = [
+            self.pod.get_static('/public/dir/.dummy_dot_file'),
+            self.pod.get_static('/public/dir/file.txt'),
             self.pod.get_static('/public/.dummy_dot_file'),
             self.pod.get_static('/public/file.txt'),
             self.pod.get_static('/public/main.css'),

--- a/grow/pods/routes_test.py
+++ b/grow/pods/routes_test.py
@@ -78,6 +78,7 @@ class RoutesTest(unittest.TestCase):
             '/public/file.txt',
             '/public/main.css',
             '/public/main.min.js',
+            '/public/dir/file.txt',
             '/root/base/',
             '/root/sitemap.xml',
             '/root/static/file-aa843134a2a113f7ebd5386c4d094a1a.min.js',

--- a/grow/pods/tags.py
+++ b/grow/pods/tags.py
@@ -56,8 +56,8 @@ def collections(collection_paths=None, _pod=None):
 
 
 @utils.memoize_tag
-def statics(pod_path, locale=None, _pod=None):
-    return list(_pod.list_statics(pod_path, locale=locale))
+def statics(pod_path, locale=None, include_hidden=False, _pod=None):
+    return list(_pod.list_statics(pod_path, locale=locale, include_hidden=include_hidden))
 
 
 def markdown_filter(value):

--- a/grow/testing/testdata/pod/public/dir/file.txt
+++ b/grow/testing/testdata/pod/public/dir/file.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
Also added tests to make sure that it works with sub directories.

Fixes #353.