### PR TITLE
Stipping all the normal non-escaped valid url characters.

### DIFF
--- a/grow/pods/tags.py
+++ b/grow/pods/tags.py
@@ -71,15 +71,10 @@ def markdown_filter(value):
         return markdown.markdown(value)
 
 
-_slug_regex = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
-
+_slug_regex = re.compile(r'[^A-Za-z0-9-._~]+')
 
 def slug_filter(value):
-    result = []
-    for word in _slug_regex.split(value.lower()):
-        if word:
-            result.append(word)
-    return unicode(u'-'.join(result))
+    return unicode(u'-'.join(_slug_regex.split(value.lower())).strip(u'-'))
 
 
 @utils.memoize_tag

--- a/grow/pods/tags_test.py
+++ b/grow/pods/tags_test.py
@@ -16,6 +16,9 @@ class BuiltinsTestCase(unittest.TestCase):
         words = 'Foo Bar Baz'
         self.assertEqual('foo-bar-baz', tags.slug_filter(words))
 
+        words = 'Foo\'s b@z b**'
+        self.assertEqual('foo-s-b-z-b', tags.slug_filter(words))
+
     def test_locale(self):
         identifier = 'de'
         expected = locales.Locale.parse(identifier)


### PR DESCRIPTION
Technically urls can contain escaped characters, but for the purpose of the slug this is being ignored.

Fixes #348