### PR TITLE
Adding the ability to 'disable' a feature in grow.

### DIFF
--- a/grow/commands/run.py
+++ b/grow/commands/run.py
@@ -36,7 +36,7 @@ def run(host, port, https, debug, browser, update_check, preprocess, ui,
     pod = pods.Pod(root, storage=storage.FileStorage, env=environment)
 
     if not ui:
-        pod.disable('ui')
+        pod.disable(pod.FEATURE_UI)
 
     try:
         manager.start(pod, host=host, port=port, open_browser=browser,

--- a/grow/commands/run.py
+++ b/grow/commands/run.py
@@ -23,7 +23,9 @@ import threading
 @click.option('--preprocess/--no-preprocess', '-p/-np',
               default=True, is_flag=True,
               help='Whether to run preprocessors on server start.')
-def run(host, port, https, debug, browser, update_check, preprocess,
+@click.option('--ui/--no-ui', '-b', is_flag=True, default=True,
+              help='Whether to inject the Grow UI Tools.')
+def run(host, port, https, debug, browser, update_check, preprocess, ui,
         pod_path):
     """Starts a development server for a single pod."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
@@ -32,6 +34,10 @@ def run(host, port, https, debug, browser, update_check, preprocess,
                            scheme=scheme, cached=False, dev=True)
     environment = env.Env(config)
     pod = pods.Pod(root, storage=storage.FileStorage, env=environment)
+
+    if not ui:
+        pod.disable('ui')
+
     try:
         manager.start(pod, host=host, port=port, open_browser=browser,
                       debug=debug, preprocess=preprocess,

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -196,7 +196,7 @@ class Pod(object):
 
     def dump(self, suffix='index.html', append_slashes=True):
         output = self.export(suffix=suffix, append_slashes=append_slashes)
-        if self.ui and not self.is_disabled(self.FEATURE_UI):
+        if self.ui and not self.is_enabled(self.FEATURE_UI):
             output.update(self.export_ui())
         return output
 
@@ -475,8 +475,8 @@ class Pod(object):
         translator.inject(doc=doc)
         return translator
 
-    def is_disabled(self, feature):
-        return feature in self._disabled
+    def is_enabled(self, feature):
+        return feature not in self._disabled
 
     def list_collections(self, paths=None):
         cols = collection.Collection.list(self)

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -49,6 +49,7 @@ class PodDoesNotExistError(Error, IOError):
 
 class Pod(object):
 
+    FEATURE_UI = 'ui'
     FILE_PODCACHE = '.podcache.yaml'
     FILE_PODSPEC = 'podspec.yaml'
 
@@ -68,6 +69,8 @@ class Pod(object):
         self.logger = _logger
         self.routes = routes.Routes(pod=self)
         self._podcache = None
+        self._disabled = set()
+
         # Ensure preprocessors are loaded when pod is initialized.
         # Preprocessors may modify the environment in ways that are required by
         # data files (e.g. yaml constructors).
@@ -188,9 +191,12 @@ class Pod(object):
         path = self._normalize_path(pod_path)
         return self.storage.delete(path)
 
+    def disable(self, feature):
+        self._disabled.add(feature)
+
     def dump(self, suffix='index.html', append_slashes=True):
         output = self.export(suffix=suffix, append_slashes=append_slashes)
-        if self.ui:
+        if self.ui and not self.is_disabled(self.FEATURE_UI):
             output.update(self.export_ui())
         return output
 
@@ -468,6 +474,9 @@ class Pod(object):
             return
         translator.inject(doc=doc)
         return translator
+
+    def is_disabled(self, feature):
+        return feature in self._disabled
 
     def list_collections(self, paths=None):
         cols = collection.Collection.list(self)

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -17,9 +17,9 @@ class PodTest(unittest.TestCase):
         self.pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
 
     def test_disable(self):
-        self.assertFalse(self.pod.is_disabled('ui'))
+        self.assertTrue(self.pod.is_enabled('ui'))
         self.pod.disable('ui')
-        self.assertTrue(self.pod.is_disabled('ui'))
+        self.assertFalse(self.pod.is_enabled('ui'))
 
     def test_eq(self):
         pod = pods.Pod(self.dir_path, storage=storage.FileStorage)

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -16,6 +16,11 @@ class PodTest(unittest.TestCase):
         self.dir_path = testing.create_test_pod_dir()
         self.pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
 
+    def test_disable(self):
+        self.assertFalse(self.pod.is_disabled('ui'))
+        self.pod.disable('ui')
+        self.assertTrue(self.pod.is_disabled('ui'))
+
     def test_eq(self):
         pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
         self.assertEqual(self.pod, pod)

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -66,8 +66,9 @@ class RenderedController(controllers.BaseController):
                 'podspec': self.pod.podspec,
             }
             content = template.render(kwargs).lstrip()
-            content = self._inject_ui(
-                content, preprocessor, translator)
+            if not self.pod.is_disabled(self.pod.FEATURE_UI):
+                content = self._inject_ui(
+                    content, preprocessor, translator)
             return content
         except Exception as e:
             text = 'Error building {}: {}'

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -66,7 +66,7 @@ class RenderedController(controllers.BaseController):
                 'podspec': self.pod.podspec,
             }
             content = template.render(kwargs).lstrip()
-            if not self.pod.is_disabled(self.pod.FEATURE_UI):
+            if self.pod.is_enabled(self.pod.FEATURE_UI):
                 content = self._inject_ui(
                     content, preprocessor, translator)
             return content


### PR DESCRIPTION
Currently able to disable the injected UI when using `grow run --no-ui`.

This could be used in the future as a way to selectively turn off features during run time without configuration.

Fixes #382