### PR TITLE
Pass Grow environment name to preprocessors.

### DIFF
--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -34,6 +34,8 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
     try:
         pod = pods.Pod(root, storage=storage.FileStorage)
         deployment = pod.get_deployment(deployment_name)
+        # use the deployment's environment for preprocessing and later steps.
+        pod.env = deployment.config.env
         if auth:
             deployment.login(auth)
         if preprocess:

--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -107,6 +107,8 @@ def get_popen_args(pod):
     node_modules_path = os.path.join(pod.root, 'node_modules', '.bin')
     env = os.environ.copy()
     env['PATH'] = str(os.environ['PATH'] + os.path.pathsep + node_modules_path)
+    if pod.env.name:
+      env['GROW_ENVIRONMENT_NAME'] = pod.env.name
     args = {
         'cwd': pod.root,
         'env': env,


### PR DESCRIPTION
Use the deployment's environment for earlier steps (such as preprocessing and stats) and not just deployment.

Exposes the name as the GROW_ENVIRONMENT_NAME environment name.