### PR TITLE
Fixing `import_translations` count and messaging.

### DIFF
--- a/grow/pods/catalog_holder.py
+++ b/grow/pods/catalog_holder.py
@@ -140,9 +140,9 @@ class Catalogs(object):
     def import_translations(self, path=None, locale=None, content=None):
         importer = importers.Importer(self.pod)
         if path:
-            importer.import_path(path, locale=locale)
+            return importer.import_path(path, locale=locale)
         if content:
-            importer.import_content(content=content, locale=locale)
+            return importer.import_content(content=content, locale=locale)
 
     def _get_or_create_catalog(self, template_path):
         exists = True

--- a/grow/pods/importers.py
+++ b/grow/pods/importers.py
@@ -106,33 +106,37 @@ class Importer(object):
 
         babel_locales = external_to_babel_locales.get(locale, [locale])
         for babel_locale in babel_locales:
-          pod_translations_dir = os.path.join(
-              'translations', babel_locale, 'LC_MESSAGES')
-          pod_po_path = os.path.join(pod_translations_dir, 'messages.po')
-          if self.pod.file_exists(pod_po_path):
-              existing_po_file = self.pod.open_file(pod_po_path)
-              existing_catalog = pofile.read_po(existing_po_file, babel_locale)
-              po_file_to_merge = cStringIO.StringIO()
-              po_file_to_merge.write(content)
-              po_file_to_merge.seek(0)
-              catalog_to_merge = pofile.read_po(po_file_to_merge, babel_locale)
-              num_imported = 0
-              for message in catalog_to_merge:
-                  if message.id not in existing_catalog:
-                      existing_catalog[message.id] = message
-                      num_imported += 1
-                  elif (message.string
-                        and existing_catalog[message.id].string != message.string):
-                      # Avoid overwriting with empty/identical strings.
-                      existing_catalog[message.id].string = message.string
-                      num_imported += 1
-              existing_po_file = self.pod.open_file(pod_po_path, mode='w')
-              pofile.write_po(existing_po_file, existing_catalog, width=80,
-                              sort_output=True, sort_by_file=True)
-              text = 'Updated {} of {} translations: {}'
-              message = text.format(num_imported, len(catalog_to_merge), babel_locale)
-              self.pod.logger.info(message)
-          else:
-              self.pod.write_file(pod_po_path, content)
-              message = 'Imported new catalog: {}'.format(babel_locale)
-              self.pod.logger.info(message)
+            pod_translations_dir = os.path.join(
+                'translations', babel_locale, 'LC_MESSAGES')
+            pod_po_path = os.path.join(pod_translations_dir, 'messages.po')
+            if self.pod.file_exists(pod_po_path):
+                existing_po_file = self.pod.open_file(pod_po_path)
+                existing_catalog = pofile.read_po(
+                    existing_po_file, babel_locale)
+                po_file_to_merge = cStringIO.StringIO()
+                po_file_to_merge.write(content)
+                po_file_to_merge.seek(0)
+                catalog_to_merge = pofile.read_po(
+                    po_file_to_merge, babel_locale)
+                num_imported = 0
+                for message in catalog_to_merge:
+                    if message.id not in existing_catalog:
+                        existing_catalog[message.id] = message
+                        num_imported += 1
+                    elif (message.string
+                          and existing_catalog[message.id].string != message.string):
+                        # Avoid overwriting with empty/identical strings.
+                        existing_catalog[message.id].string = message.string
+                        num_imported += 1
+
+                existing_po_file = self.pod.open_file(pod_po_path, mode='w')
+                pofile.write_po(existing_po_file, existing_catalog, width=80,
+                                sort_output=True, sort_by_file=True)
+                text = 'Updated {} of {} translations: {}'
+                message = text.format(num_imported, len(
+                    catalog_to_merge), babel_locale)
+                self.pod.logger.info(message)
+            else:
+                self.pod.write_file(pod_po_path, content)
+                message = 'Imported new catalog: {}'.format(babel_locale)
+                self.pod.logger.info(message)

--- a/grow/pods/importers.py
+++ b/grow/pods/importers.py
@@ -122,20 +122,26 @@ class Importer(object):
                 for message in catalog_to_merge:
                     if message.id not in existing_catalog:
                         existing_catalog[message.id] = message
-                        num_imported += 1
+                        if message.id:  # Only count the non-header messages.
+                            num_imported += 1
                     elif (message.string
                           and existing_catalog[message.id].string != message.string):
                         # Avoid overwriting with empty/identical strings.
                         existing_catalog[message.id].string = message.string
                         num_imported += 1
 
-                existing_po_file = self.pod.open_file(pod_po_path, mode='w')
-                pofile.write_po(existing_po_file, existing_catalog, width=80,
-                                sort_output=True, sort_by_file=True)
-                text = 'Updated {} of {} translations: {}'
-                message = text.format(num_imported, len(
-                    catalog_to_merge), babel_locale)
-                self.pod.logger.info(message)
+                if num_imported > 0:
+                    existing_po_file = self.pod.open_file(pod_po_path, mode='w')
+                    pofile.write_po(existing_po_file, existing_catalog, width=80,
+                                    sort_output=True, sort_by_file=True)
+                    text = 'Updated {} of {} translations: {}'
+                    message = text.format(num_imported, len(
+                        catalog_to_merge), babel_locale)
+                    self.pod.logger.info(message)
+                else:
+                    text = 'No translations updated: {}'
+                    message = text.format(babel_locale)
+                    self.pod.logger.info(message)
             else:
                 self.pod.write_file(pod_po_path, content)
                 message = 'Imported new catalog: {}'.format(babel_locale)

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -129,12 +129,16 @@ class Translator(object):
                 thread.join()
         if not inject:
             bar.finish()
+
+        has_changed_content = False
         for lang, translations in langs_to_translations.iteritems():
             if inject:
-                self.pod.catalogs.inject_translations(locale=lang, content=translations)
-            else:
-                self.pod.catalogs.import_translations(locale=lang, content=translations)
-        if save_stats:
+                if self.pod.catalogs.inject_translations(locale=lang, content=translations):
+                    has_changed_content = True
+            elif self.pod.catalogs.import_translations(locale=lang, content=translations):
+                has_changed_content = True
+
+        if save_stats and has_changed_content:
             self.save_stats(new_stats)
         return new_stats
 


### PR DESCRIPTION
When doing `import_translations` there would always be 1 message that would be updated, even if the file doesn't change. Also, the count of messages imported was always off by one. ex: `Updated 3 of 2 translations: de`.

This fixes the empty message ids to not count towards messages and for them to no cause the file to be rewritten if none of the actual messages are updated.