### PR TITLE
Correctly split the document front matter with whitespace by boundary.

### DIFF
--- a/grow/pods/document_front_matter.py
+++ b/grow/pods/document_front_matter.py
@@ -7,7 +7,7 @@ import collections
 import re
 import yaml
 
-BOUNDARY_REGEX = re.compile(r'^-{3,}$', re.MULTILINE)
+BOUNDARY_REGEX = re.compile(r'^-{3,}\s*$', re.MULTILINE)
 CONVERT_MESSAGE = """Document contains too many parts: {},
     Please run `grow convert --type content_locale_split` to help update files."""
 


### PR DESCRIPTION
In systems that use different line endings or if there are trailing whitespace the document front matter would not correctly split.

Fixes #442