### PR TITLE
Manifest generation

### DIFF
--- a/grow/commands/__init__.py
+++ b/grow/commands/__init__.py
@@ -4,6 +4,7 @@ from . import deploy
 from . import download_translations
 from . import extract
 from . import filter
+from . import generate_manifest
 from . import import_translations
 from . import init
 from . import install
@@ -23,6 +24,7 @@ def add(group):
     group.add_command(download_translations.download_translations)
     group.add_command(extract.extract)
     group.add_command(filter.filter)
+    group.add_command(generate_manifest.generate_manifest)
     group.add_command(import_translations.import_translations)
     group.add_command(init.init)
     group.add_command(machine_translate.machine_translate)

--- a/grow/commands/generate_manifest.py
+++ b/grow/commands/generate_manifest.py
@@ -1,0 +1,20 @@
+from grow.pods import pods
+from grow.pods import storage
+import click
+import os
+import json
+
+
+@click.command()
+@click.argument('statics_path')
+@click.argument('pod_path', default='.')
+def generate_manifest(statics_path, pod_path):
+    """Generates a g.static manifiest given a pod path."""
+    root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
+    pod = pods.Pod(root, storage=storage.FileStorage)
+    try:
+        with open('manifest.json', 'w') as f:
+            data = {static.pod_path: static.url.path for static in pod.list_statics(statics_path)}
+            f.write(json.dumps(data))
+    except pods.Error as e:
+        raise click.ClickException(str(e))

--- a/grow/commands/generate_manifest.py
+++ b/grow/commands/generate_manifest.py
@@ -7,13 +7,14 @@ import json
 
 @click.command()
 @click.argument('statics_path')
+@click.argument('manifest_path', default="manifest.json")
 @click.argument('pod_path', default='.')
-def generate_manifest(statics_path, pod_path):
+def generate_manifest(statics_path, manifest_path, pod_path):
     """Generates a g.static manifiest given a pod path."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     pod = pods.Pod(root, storage=storage.FileStorage)
     try:
-        with open('manifest.json', 'w') as f:
+        with open(manifest_path, 'w') as f:
             data = {static.pod_path: static.url.path for static in pod.list_statics(statics_path)}
             f.write(json.dumps(data))
     except pods.Error as e:


### PR DESCRIPTION
Command to generate a manifest using list_statics, this is useful if you have a build pipeline that needs access to the static paths.