### PR TITLE
Make Grow-managed extensions directory user-customizable.

### DIFF
--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -14,7 +14,6 @@ from grow.common import utils
 from xtermcolor import colorize
 
 
-EXTENSIONS_DIR_NAME = 'extensions'
 VERSION = config.VERSION
 RELEASES_API = 'https://api.github.com/repos/grow/grow/releases'
 INSTALLER_COMMAND = ('/usr/bin/python -c "$(curl -fsSL '
@@ -216,7 +215,8 @@ def install_bower(pod):
     if bower_not_found:
         pod.logger.error('[✘] The "bower" command was not found.')
         pod.logger.error(
-            '    Either add bower to package.json or install globally using: sudo npm install -g bower')
+            '    Either add bower to package.json or install globally using:'
+            ' sudo npm install -g bower')
         return
     pod.logger.info('[✓] "bower" is installed.')
     bower_command = 'bower install'
@@ -236,7 +236,8 @@ def install_gulp(pod):
     if gulp_not_found:
         pod.logger.error('[✘] The "gulp" command was not found.')
         pod.logger.error(
-            '    Either add gulp to package.json or install globally using: sudo npm install -g gulp')
+            '    Either add gulp to package.json or install globally using:'
+            ' sudo npm install -g gulp')
         return
     pod.logger.info('[✓] "gulp" is installed.')
     return True
@@ -250,18 +251,20 @@ def install_extensions(pod):
     if pip_not_found:
         pod.logger.error('[✘] The "pip" command was not found.')
         return
+    extensions_dir = pod.extensions_dir
     pod.logger.info('[✓] "pip" is installed.')
-    pip_command = 'pip install -U -t {} -r extensions.txt'.format(EXTENSIONS_DIR_NAME)
+    command = 'pip install -U -t {} -r extensions.txt'
+    pip_command = command.format(extensions_dir)
     process = subprocess.Popen(pip_command, shell=True, **args)
     code = process.wait()
     if not code:
-        init_file_name = '/{}/__init__.py'.format(EXTENSIONS_DIR_NAME)
+        init_file_name = '/{}/__init__.py'.format(extensions_dir)
         if not pod.file_exists(init_file_name):
             pod.write_file(init_file_name, '')
-        pod.logger.info('[✓] Installed: Grow extensions from extensions.txt.')
+        text = '[✓] Installed: extensions.txt -> {}'
+        pod.logger.info(text.format(extensions_dir))
         return True
-    pod.logger.error(
-        '[✘] There was an error running "pip install -t ext -r extensions.txt".')
+    pod.logger.error('[✘] There was an error running "{}".'.format(pip_command))
 
 
 def install_yarn(pod):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -48,7 +48,7 @@ class PodDoesNotExistError(Error, IOError):
 # "podspec" class.
 
 class Pod(object):
-
+    DEFAULT_EXTENSIONS_DIR_NAME = 'extensions'
     FEATURE_UI = 'ui'
     FILE_PODCACHE = '.podcache.yaml'
     FILE_PODSPEC = 'podspec.yaml'
@@ -71,17 +71,16 @@ class Pod(object):
         self._podcache = None
         self._disabled = set()
 
-        # Modify sys.path for built-in extension support.
-        _ext_dir = os.path.join(self.root, sdk_utils.EXTENSIONS_DIR_NAME)
-        if os.path.exists(_ext_dir):
-            sys.path.insert(0, _ext_dir)
-
         # Ensure preprocessors are loaded when pod is initialized.
         # Preprocessors may modify the environment in ways that are required by
         # data files (e.g. yaml constructors). Avoid loading extensions using
         # `load_extensions=False` to permit `grow install` to be used to
         # actually install extensions, prior to loading them.
         if load_extensions and self.exists:
+            # Modify sys.path for built-in extension support.
+            _ext_dir = self.abs_path(self.extensions_dir)
+            if os.path.exists(_ext_dir):
+                sys.path.insert(0, _ext_dir)
             self.list_preprocessors()
         try:
             sdk_utils.check_sdk_version(self)
@@ -162,6 +161,10 @@ class Pod(object):
     @property
     def title(self):
         return self.yaml.get('title')
+
+    @property
+    def extensions_dir(self):
+        return self.yaml.get('extensions_dir', Pod.DEFAULT_EXTENSIONS_DIR_NAME)
 
     @property
     def ui(self):


### PR DESCRIPTION
I realized that some users may already be using the `extensions` directory as a place for site-specific extensions that are written and committed to Git. Our goal with `extensions.txt`-managed extensions is to have that directory `.gitignore`d, so it makes sense to allow users to change the managed/ignored directory if they are already using the `extensions` directory. I expect this feature to not be used much, but it is a quick add with a lot of user-friendliness.