### PR TITLE
Add support for @env.<name> conditional yaml syntax.

### DIFF
--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -35,7 +35,7 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
         pod = pods.Pod(root, storage=storage.FileStorage)
         deployment = pod.get_deployment(deployment_name)
         # use the deployment's environment for preprocessing and later steps.
-        pod.env = deployment.config.env
+        pod.set_env(deployment.config.env)
         if auth:
             deployment.login(auth)
         if preprocess:

--- a/grow/commands/run.py
+++ b/grow/commands/run.py
@@ -26,8 +26,10 @@ from grow.server import manager
               help='Whether to run preprocessors on server start.')
 @click.option('--ui/--no-ui', is_flag=True, default=True,
               help='Whether to inject the Grow UI Tools.')
+@click.option('--deployment', default=None,
+              help='Name of the deployment to use.')
 def run(host, port, https, debug, browser, update_check, preprocess, ui,
-        pod_path):
+        pod_path, deployment):
     """Starts a development server for a single pod."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     scheme = 'https' if https else 'http'
@@ -35,10 +37,11 @@ def run(host, port, https, debug, browser, update_check, preprocess, ui,
                            scheme=scheme, cached=False, dev=True)
     environment = env.Env(config)
     pod = pods.Pod(root, storage=storage.FileStorage, env=environment)
-
+    if deployment:
+        deployment_obj = pod.get_deployment(deployment)
+        pod.set_env(deployment_obj.config.env)
     if not ui:
         pod.disable(pod.FEATURE_UI)
-
     try:
         manager.start(pod, host=host, port=port, open_browser=browser,
                       debug=debug, preprocess=preprocess,

--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -45,7 +45,7 @@ class AmazonS3Destination(base.BaseDestination):
             raise
 
     def dump(self, pod):
-        pod.env = self.get_env()
+        pod.set_env(self.get_env())
         return pod.dump(
             suffix=self.config.index_document,
             append_slashes=self.config.redirect_trailing_slashes)

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -227,7 +227,7 @@ class BaseDestination(object):
         pass
 
     def dump(self, pod):
-        pod.env = self.get_env()
+        pod.set_env(self.get_env())
         return pod.dump()
 
     def deploy(self, paths_to_contents, stats=None,

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -72,7 +72,7 @@ class GoogleCloudStorageDestination(base.BaseDestination):
             raise
 
     def dump(self, pod):
-        pod.env = self.get_env()
+        pod.set_env(self.get_env())
         return pod.dump(
             suffix=self.config.main_page_suffix,
             append_slashes=self.config.redirect_trailing_slashes)

--- a/grow/pods/collection.py
+++ b/grow/pods/collection.py
@@ -154,7 +154,8 @@ class Collection(object):
 
     @utils.cached_property
     def fields(self):
-        fields = document_fields.DocumentFields.untag(self.tagged_fields)
+        untag = document_fields.DocumentFields.untag
+        fields = untag(self.tagged_fields, env_name=self.pod.env.name)
         return {} if not fields else fields
 
     @utils.cached_property

--- a/grow/pods/collection.py
+++ b/grow/pods/collection.py
@@ -154,7 +154,7 @@ class Collection(object):
 
     @utils.cached_property
     def fields(self):
-        fields = document_fields.DocumentFields._untag(self.tagged_fields)
+        fields = document_fields.DocumentFields.untag(self.tagged_fields)
         return {} if not fields else fields
 
     @utils.cached_property

--- a/grow/pods/document_fields_test.py
+++ b/grow/pods/document_fields_test.py
@@ -76,7 +76,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'nested': 'sub-sub-nested-value',
                 },
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
 
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
@@ -91,7 +91,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'nested': 'sub-sub-nested-value',
                 },
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
 
         fields_to_test = {
             'foo': 'bar-base',
@@ -108,14 +108,14 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'nested': 'nested-fr',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'foo': 'bar-de',
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
 
         fields_to_test = {
             'list': [
@@ -145,7 +145,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'item': 'value-3-fr',
                 },
             ]
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'list': [
@@ -157,7 +157,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                 },
                 {},
             ]
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
         self.assertDictEqual({
             'list': [
                 {
@@ -168,7 +168,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                 },
                 {},
             ]
-        }, document_fields.DocumentFields._untag(fields, locale='ja'))
+        }, document_fields.DocumentFields.untag(fields, locale='ja'))
 
         fields_to_test = {
             '$view': '/views/base.html',
@@ -194,7 +194,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'nested': 'nested-ja',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='ja'))
+        }, document_fields.DocumentFields.untag(fields, locale='ja'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             '$view': '/views/base.html',
@@ -203,7 +203,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
 
         fields_to_test = {
             'foo@': 'bar',
@@ -212,13 +212,13 @@ class DocumentFieldsTestCase(unittest.TestCase):
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'foo': 'bar',
-        }, document_fields.DocumentFields._untag(fields))
+        }, document_fields.DocumentFields.untag(fields))
         self.assertDictEqual({
             'foo': 'bar',
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
         self.assertDictEqual({
             'foo': 'bar-fr',
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
 
         fields_to_test = {
             'list@': [
@@ -244,7 +244,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                 'value2',
                 'value3',
             ],
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'list': [
@@ -257,7 +257,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                 'value2-fr',
                 'value3-fr',
             ],
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
 
         fields_to_test = {
             'nested1': {
@@ -310,7 +310,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'value2',
                 ],
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'nested1': {
@@ -335,7 +335,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'value2-fr',
                 ],
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
 
     def test_untag_with_backwards_compatibility(self):
         fields_to_test = {
@@ -372,7 +372,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
                     'value1',
                 ],
             },
-        }, document_fields.DocumentFields._untag(fields))
+        }, document_fields.DocumentFields.untag(fields))
 
     def test_untag_with_regex(self):
         fields_to_test = {
@@ -391,31 +391,31 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'nested': 'nested-fr',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
         self.assertDictEqual({
             'foo': 'bar-fr',
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr_FR'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr_FR'))
         self.assertDictEqual({
             'foo': 'bar-fr',
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr_CA'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr_CA'))
         self.assertDictEqual({
             'foo': 'bar-de',
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
         self.assertDictEqual({
             'foo': 'bar-base',
             'nested': {
                 'nested': 'nested-de',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de_AT'))
+        }, document_fields.DocumentFields.untag(fields, locale='de_AT'))
 
         fields_to_test = {
             'foo': 'bar-base',
@@ -432,21 +432,71 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'nested': 'nested-any',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='fr'))
+        }, document_fields.DocumentFields.untag(fields, locale='fr'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'foo': 'bar-any',
             'nested': {
                 'nested': 'nested-any',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='it'))
+        }, document_fields.DocumentFields.untag(fields, locale='it'))
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'foo': 'bar-de',
             'nested': {
                 'nested': 'nested-base',
             },
-        }, document_fields.DocumentFields._untag(fields, locale='de'))
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
+
+    def test_untag_env_name(self):
+        untag = document_fields.DocumentFields.untag
+        fields_to_test = {
+            'foo': 'base',
+            'foo@env.dev': 'dev',
+            'foo@env.prod': 'prod',
+        }
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'foo': 'base',
+        }, untag(fields, locale=None, env_name=None))
+        self.assertDictEqual({
+            'foo': 'dev',
+        }, untag(fields, locale=None, env_name='dev'))
+        self.assertDictEqual({
+            'foo': 'prod',
+        }, untag(fields, locale=None, env_name='prod'))
+        fields_to_test = {
+            'nested': {
+                'foo': 'nested-base',
+            },
+            'nested@de': {
+                'foo': 'nested-de-base',
+                'foo@env.dev': 'nested-de-dev',
+                'foo@env.prod': 'nested-de-prod',
+            }
+        }
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({
+            'nested': {
+                'foo': 'nested-base',
+            },
+        }, untag(fields, locale=None, env_name=None))
+        self.assertDictEqual({
+            'nested': {
+                'foo': 'nested-base',
+            },
+        }, untag(fields, locale=None, env_name='dev'))
+        self.assertDictEqual({
+            'nested': {
+                'foo': 'nested-de-dev',
+            },
+        }, untag(fields, locale='de', env_name='dev'))
+        self.assertDictEqual({
+            'nested': {
+                'foo': 'nested-de-prod',
+            },
+        }, untag(fields, locale='de', env_name='prod'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -197,7 +197,8 @@ class Document(object):
         locale_identifier = str(
             self._locale_kwarg or self.collection.default_locale)
         return document_fields.DocumentFields(
-            self.format.front_matter.data, locale_identifier)
+            self.format.front_matter.data, locale_identifier,
+            env_name=self.pod.env.name)
 
     @utils.cached_property
     def footnotes(self):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -59,6 +59,7 @@ class Pod(object):
                 and self.root == other.root)
 
     def __init__(self, root, storage=storage.auto, env=None, load_extensions=True):
+        self._yaml = utils.SENTINEL
         self.storage = storage
         self.root = (root if self.storage.is_cloud_storage
                      else os.path.abspath(root))
@@ -125,6 +126,16 @@ class Pod(object):
                 raise PodDoesNotExistError('Pod not found in: {}'.format(path))
             raise podspec.PodSpecParseError('Error parsing: {}'.format(path))
 
+    def set_env(self, env):
+        if env.name:
+            untag = document_fields.DocumentFields.untag
+            content = untag(self.yaml, env_name=env.name)
+            self._yaml = content
+            # Preprocessors may depend on env, reset cache.
+            # pylint: disable=no-member
+            self.list_preprocessors.reset()
+        self.env = env
+
     @utils.cached_property
     def cache(self):
         if utils.is_appengine():
@@ -180,7 +191,9 @@ class Pod(object):
 
     @property
     def yaml(self):
-        return self._parse_yaml() or {}
+        if self._yaml is utils.SENTINEL:
+            self._yaml = self._parse_yaml() or {}
+        return self._yaml
 
     def abs_path(self, pod_path):
         path = os.path.join(self.root, pod_path.lstrip('/'))
@@ -658,7 +671,7 @@ class Pod(object):
 
     def read_yaml(self, path):
         fields = utils.parse_yaml(self.read_file(path), pod=self)
-        return document_fields.DocumentFields._untag(fields)
+        return document_fields.DocumentFields.untag(fields)
 
     def reset_yaml(self):
         # Tell the cached property to reset.

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -129,7 +129,7 @@ class Pod(object):
     def set_env(self, env):
         if env.name:
             untag = document_fields.DocumentFields.untag
-            content = untag(self.yaml, env_name=env.name)
+            content = untag(self._parse_yaml(), env_name=env.name)
             self._yaml = content
             # Preprocessors may depend on env, reset cache.
             # pylint: disable=no-member

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -134,6 +134,7 @@ class Pod(object):
             # Preprocessors may depend on env, reset cache.
             # pylint: disable=no-member
             self.list_preprocessors.reset()
+            self.podcache.reset()
         self.env = env
 
     @utils.cached_property
@@ -671,7 +672,8 @@ class Pod(object):
 
     def read_yaml(self, path):
         fields = utils.parse_yaml(self.read_file(path), pod=self)
-        return document_fields.DocumentFields.untag(fields)
+        untag = document_fields.DocumentFields.untag
+        return untag(fields, env_name=self.env.name)
 
     def reset_yaml(self):
         # Tell the cached property to reset.

--- a/grow/pods/routes.py
+++ b/grow/pods/routes.py
@@ -116,7 +116,8 @@ class Routes(object):
         path = '' if path is None else path
         if 'root' in self.podspec:
             path = path.replace('{root}', self.podspec['root'])
-        path = path.replace('{env.fingerprint}', self.pod.env.fingerprint)
+        if self.pod.env.fingerprint:
+            path = path.replace('{env.fingerprint}', self.pod.env.fingerprint)
         path = path.replace('{fingerprint}', '<grow:fingerprint>')
         path = path.replace('//', '/')
         return path

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -309,7 +309,7 @@ class GoogleSheetsPreprocessor(BaseGooglePreprocessor):
             preserve=self.config.preserve, existing_data=existing_data,
             key_to_update=key_to_update)
         fields = self._normalize_formatted_content(fields)
-        fields = document_fields.DocumentFields._untag(fields)
+        fields = document_fields.DocumentFields.untag(fields)
         doc.inject(fields=fields)
 
     def get_edit_url(self, doc=None):


### PR DESCRIPTION
Adds the ability to conditionally set parameters for YAML data (including in podspec) to configure things based on the environment name. See explanation in https://github.com/grow/grow/issues/464

Adds ability to do stuff like the following:

```
foo: bar-anywhere-but-prod
foo@env.prod: bar-in-prod
```

/cc @uxder @stevenle @kezlya 