### PR TITLE
Adding representers for yaml dumping.

### DIFF
--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import yaml
 
 
 PATH_LOCALE_REGEX = re.compile(r'@([^-_]+)([-_]?)([^\.]*)(\.[^\.]+)$')
@@ -455,3 +456,10 @@ class Document(object):
         self.format.update(fields=fields, content=body)
         new_content = self.format.to_raw_content()
         self.pod.write_file(self.pod_path, new_content)
+
+
+# Allow the yaml dump to write out a representation of the document.
+def doc_representer(dumper, data):
+    return dumper.represent_scalar(u'!g.doc', data.pod_path)
+
+yaml.SafeDumper.add_representer(Document, doc_representer)

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -2,6 +2,7 @@
 
 import textwrap
 import unittest
+from grow.common import utils
 from grow.testing import testing
 from . import documents
 from . import locales
@@ -731,6 +732,22 @@ class DocumentsTestCase(unittest.TestCase):
             '/content/partials/partial@de.yaml',
             '/content/pages/page.yaml',
         ]), dependents)
+
+    def test_yaml_dump(self):
+        """Test if the yaml representer is working correctly."""
+        pod = testing.create_pod()
+        pod.write_yaml('/podspec.yaml', {})
+        pod.write_yaml('/content/pages/page.yaml', {})
+        doc = pod.get_doc('/content/pages/page.yaml')
+        input_obj = {
+            'doc': doc
+        }
+        expected = textwrap.dedent(
+            """\
+            doc: !g.doc '/content/pages/page.yaml'
+            """)
+
+        self.assertEqual(expected, utils.dump_yaml(input_obj))
 
 
 if __name__ == '__main__':

--- a/grow/pods/static.py
+++ b/grow/pods/static.py
@@ -10,6 +10,7 @@ import os
 import re
 import time
 import webob
+import yaml
 
 mimetypes.add_type('application/font-woff', '.woff')
 mimetypes.add_type('application/font-woff', '.woff')
@@ -310,3 +311,10 @@ class StaticController(controllers.BaseController):
                     concrete_paths.add(matched_path)
 
         return list(concrete_paths)
+
+
+# Allow the yaml dump to write out a representation of the static file.
+def static_representer(dumper, data):
+    return dumper.represent_scalar(u'!g.static', data.pod_path)
+
+yaml.SafeDumper.add_representer(StaticFile, static_representer)

--- a/grow/pods/static_test.py
+++ b/grow/pods/static_test.py
@@ -1,8 +1,12 @@
-from . import static
+"""Tests for the static file object."""
+
+import textwrap
+import unittest
+from grow.common import utils
 from grow.pods import pods
 from grow.pods import storage
 from grow.testing import testing
-import unittest
+from . import static
 
 
 class StaticTest(unittest.TestCase):
@@ -58,6 +62,18 @@ class StaticTest(unittest.TestCase):
         path = '/path-path/file-{}.min.js'.format(fingerprint)
         expected = '/path-path/file.min.js'
         self.assertEqual(expected, static.StaticFile.remove_fingerprint(path))
+
+    def test_yaml_dump(self):
+        """Test if the yaml representer is working correctly."""
+        static_file = self.pod.get_static('/static/test.txt')
+        input_obj = {
+            'static': static_file
+        }
+        expected = textwrap.dedent(
+            """\
+            static: !g.static '/static/test.txt'
+            """)
+        self.assertEqual(expected, utils.dump_yaml(input_obj))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows for yaml dumping of `Document` and `StaticFile` classes into the correct constructor format. For example `!g.doc` or `!g.static`.