### PR TITLE
Missing the pip on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ before_script:
   then brew unlink python;
   brew install python;
   which pip2;
+  type pip2;
+  type pip;
   alias pip=/usr/local/bin/pip2;
+  type pip;
   pip install virtualenv;
   fi
 - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,11 @@ before_script:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
   then brew unlink python;
   brew install python;
-  which pip2;
-  type pip2;
-  type pip;
-  alias pip=/usr/local/bin/pip2;
-  type pip;
-  pip install virtualenv;
+  pip2 install virtualenv;
   fi
-- pip install -U pip
-- pip install -r requirements-dev.txt
-- pip install coveralls
+- pip2 install -U pip
+- pip2 install -r requirements-dev.txt
+- pip2 install coveralls
 - wget -nv https://storage.googleapis.com/appengine-sdks/featured/${GAE_ZIP}
 - unzip -q ${GAE_ZIP} -d ${HOME}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_script:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
   then brew unlink python;
   brew install python;
-  which pip2
-  which pip
+  which pip2;
+  alias pip=/usr/local/bin/pip2;
   pip install virtualenv;
   fi
 - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_script:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
   then brew unlink python;
   brew install python;
+  which pip2
+  which pip
   pip install virtualenv;
   fi
 - pip install -U pip


### PR DESCRIPTION
Homebrew updated their recipe for python to longer have a `pip` reference, instead you now have to use `pip2`.

Tried aliasing it as `pip` but that wasn't working. Went with the straight change to `pip2`. Seems to be working on both linux and osx.