### PR TITLE
Adding deep references for yaml in the `g.yaml` constructor. 

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -252,7 +252,19 @@ def make_yaml_loader(pod, doc=None):
             return self._construct_func(node, func)
 
         def construct_yaml(self, node):
-            return self._construct_func(node, pod.read_yaml)
+            def func(path):
+                if '?' in path:
+                    path, reference = path.split('?')
+                    data = pod.read_yaml(path)
+                    for key in reference.split('.'):
+                        print key, data
+                        if data and key in data:
+                            data = data[key]
+                        else:
+                            data = None
+                    return data
+                return pod.read_yaml(path)
+            return self._construct_func(node, func)
 
     YamlLoader.add_constructor(u'!_', YamlLoader.construct_gettext)
     YamlLoader.add_constructor(u'!g.csv', YamlLoader.construct_csv)

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -257,7 +257,6 @@ def make_yaml_loader(pod, doc=None):
                     path, reference = path.split('?')
                     data = pod.read_yaml(path)
                     for key in reference.split('.'):
-                        print key, data
                         if data and key in data:
                             data = data[key]
                         else:

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -119,6 +119,14 @@ class UtilsTestCase(unittest.TestCase):
         ]
         self.assertEqual(expected_docs, result['docs'])
 
+        # Test that deep linking to yaml files works.
+        expected_deep_yaml = {
+            'test': 'deep',
+            'deep': 'deeper',
+        }
+        self.assertEqual(expected_deep_yaml, result['deep'])
+        self.assertEqual(None, result['unfathomable'])
+
     def test_process_google_comments(self):
         # Google comment link.
         raw = '<div><a id="cmnt" href="https://grow.io/">Link</a></div>'

--- a/grow/testing/testdata/pod/data/constructors.yaml
+++ b/grow/testing/testdata/pod/data/constructors.yaml
@@ -3,3 +3,5 @@ docs: !g.doc
 - /content/pages/home.yaml
 - /content/pages/about.yaml
 - /content/pages/home.yaml
+deep: !g.yaml /data/deep.yaml?nested.key
+unfathomable: !g.yaml /data/deep.yaml?not.really.there

--- a/grow/testing/testdata/pod/data/deep.yaml
+++ b/grow/testing/testdata/pod/data/deep.yaml
@@ -1,0 +1,7 @@
+howdy:
+  saying: true
+nested:
+  birds: false
+  key:
+    test: 'deep'
+    deep: 'deeper'


### PR DESCRIPTION
Allows for loading a yaml document and then only using a specific key from the imported file.

Uses the following format the the yaml constructor:

`!g.yaml /content/shared/stuff.yaml?drill.down.to.stuff`

Which translates to `stuff['drill']['down']['to']['stuff']` being used as the value instead of the entire yaml file.

When there is no matching key in the file it returns a `None` value.