### PR TITLE
Incremental builds for `grow build`

### DIFF
--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -1,10 +1,12 @@
+"""Command for building pods into static deployments."""
+
+import os
+import click
 from grow.common import utils
 from grow.deployments import stats
 from grow.deployments.destinations import local as local_destination
 from grow.pods import pods
 from grow.pods import storage
-import click
-import os
 
 
 @click.command()
@@ -16,8 +18,8 @@ import os
 @click.option('--clear_cache',
               default=False, is_flag=True,
               help='Clear the pod cache before building.')
-@click.option('--files', help='Build only pages affected by content files.', multiple=True)
-def build(pod_path, out_dir, preprocess, clear_cache, files):
+@click.option('--file', '--pod_path', 'pod_paths', help='Build only pages affected by content files.', multiple=True)
+def build(pod_path, out_dir, preprocess, clear_cache, pod_paths):
     """Generates static files and dumps them to a local destination."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     out_dir = out_dir or os.path.join(root, 'build')
@@ -29,11 +31,11 @@ def build(pod_path, out_dir, preprocess, clear_cache, files):
     try:
         config = local_destination.Config(out_dir=out_dir)
         destination = local_destination.LocalDestination(config)
-        paths_to_contents = destination.dump(pod, files=files)
+        paths_to_contents = destination.dump(pod, pod_paths=pod_paths)
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
         destination.deploy(paths_to_contents, stats=stats_obj, repo=repo, confirm=False,
-                           test=False, is_partial=bool(files))
+                           test=False, is_partial=bool(pod_paths))
         pod.podcache.write()
     except pods.Error as e:
         raise click.ClickException(str(e))

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -16,7 +16,8 @@ import os
 @click.option('--clear_cache',
               default=False, is_flag=True,
               help='Clear the pod cache before building.')
-def build(pod_path, out_dir, preprocess, clear_cache):
+@click.option('--files', help='Build only pages affected by content files.', multiple=True)
+def build(pod_path, out_dir, preprocess, clear_cache, files):
     """Generates static files and dumps them to a local destination."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     out_dir = out_dir or os.path.join(root, 'build')
@@ -28,7 +29,7 @@ def build(pod_path, out_dir, preprocess, clear_cache):
     try:
         config = local_destination.Config(out_dir=out_dir)
         destination = local_destination.LocalDestination(config)
-        paths_to_contents = destination.dump(pod)
+        paths_to_contents = destination.dump(pod, files=files)
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
         destination.deploy(paths_to_contents, stats=stats_obj, repo=repo, confirm=False,

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -33,7 +33,7 @@ def build(pod_path, out_dir, preprocess, clear_cache, files):
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
         destination.deploy(paths_to_contents, stats=stats_obj, repo=repo, confirm=False,
-                           test=False)
+                           test=False, is_partial=bool(files))
         pod.podcache.write()
     except pods.Error as e:
         raise click.ClickException(str(e))

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -230,8 +230,8 @@ class BaseDestination(object):
         pod.set_env(self.get_env())
         return pod.dump(files=files)
 
-    def deploy(self, paths_to_contents, stats=None,
-               repo=None, dry_run=False, confirm=False, test=True):
+    def deploy(self, paths_to_contents, stats=None, repo=None, dry_run=False,
+               confirm=False, test=True, is_partial=False):
         self._confirm = confirm
         self.prelaunch(dry_run=dry_run)
         if test:
@@ -241,7 +241,8 @@ class BaseDestination(object):
             new_index = indexes.Index.create(paths_to_contents)
             if repo:
                 indexes.Index.add_repo(new_index, repo)
-            diff = indexes.Diff.create(new_index, deployed_index, repo=repo)
+            diff = indexes.Diff.create(
+                new_index, deployed_index, repo=repo, is_partial=is_partial)
             self._diff = diff
             if indexes.Diff.is_empty(diff):
                 logging.info('Finished with no diffs since the last build.')
@@ -255,8 +256,9 @@ class BaseDestination(object):
                     logging.info('Aborted.')
                     return
             indexes.Diff.apply(
-                diff, paths_to_contents, write_func=self.write_file, batch_write_func=self.write_files,
-                delete_func=self.delete_file, threaded=self.threaded, batch_writes=self.batch_writes)
+                diff, paths_to_contents, write_func=self.write_file,
+                batch_write_func=self.write_files, delete_func=self.delete_file,
+                threaded=self.threaded, batch_writes=self.batch_writes)
             self.write_control_file(
                 self.index_basename, indexes.Index.to_string(new_index))
             if stats is not None:

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -226,9 +226,9 @@ class BaseDestination(object):
     def login(self, account, reauth=False):
         pass
 
-    def dump(self, pod):
+    def dump(self, pod, files=None):
         pod.set_env(self.get_env())
-        return pod.dump()
+        return pod.dump(files=files)
 
     def deploy(self, paths_to_contents, stats=None,
                repo=None, dry_run=False, confirm=False, test=True):

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -226,9 +226,9 @@ class BaseDestination(object):
     def login(self, account, reauth=False):
         pass
 
-    def dump(self, pod, files=None):
+    def dump(self, pod, pod_paths=None):
         pod.set_env(self.get_env())
-        return pod.dump(files=files)
+        return pod.dump(pod_paths=pod_paths)
 
     def deploy(self, paths_to_contents, stats=None, repo=None, dry_run=False,
                confirm=False, test=True, is_partial=False):

--- a/grow/deployments/indexes.py
+++ b/grow/deployments/indexes.py
@@ -152,9 +152,8 @@ class Diff(object):
                 diff.deletes.append(file_message)
 
         # What changed in the pod between deploy commits.
-        if (repo is not None
-            and index.commit and index.commit.sha
-                and theirs.commit and theirs.commit.sha):
+        if (repo is not None and index.commit and index.commit.sha and theirs.commit
+                and theirs.commit.sha):
             try:
                 what_changed = repo.git.log(
                     '--date=short',

--- a/grow/deployments/messages.py
+++ b/grow/deployments/messages.py
@@ -43,6 +43,7 @@ class DiffMessage(messages.Message):
     nochanges = messages.MessageField(FileMessage, 4, repeated=True)
     indexes = messages.MessageField(IndexMessage, 5, repeated=True)
     what_changed = messages.StringField(6)
+    is_partial = messages.BooleanField(7)
 
 
 class FileCountMessage(messages.Message):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -212,24 +212,24 @@ class Pod(object):
     def disable(self, feature):
         self._disabled.add(feature)
 
-    def dump(self, suffix='index.html', append_slashes=True, files=None):
+    def dump(self, suffix='index.html', append_slashes=True, pod_paths=None):
         output = self.export(
-            suffix=suffix, append_slashes=append_slashes, files=files)
+            suffix=suffix, append_slashes=append_slashes, pod_paths=pod_paths)
         if self.ui and not self.is_enabled(self.FEATURE_UI):
             output.update(self.export_ui())
         return output
 
-    def export(self, suffix=None, append_slashes=False, files=None):
+    def export(self, suffix=None, append_slashes=False, pod_paths=None):
         """Builds the pod, returning a mapping of paths to content based on pod routes."""
-        if files:
-            # When provided a list of files do a custom routing tree based on
+        if pod_paths:
+            # When provided a list of pod_paths do a custom routing tree based on
             # the docs that are dependent based on the dependecy graph.
-            def _gen_docs(files):
-                for pod_path in files:
+            def _gen_docs(pod_paths):
+                for pod_path in pod_paths:
                     for dep_path in self.podcache.dependency_graph.get_dependents(
                             pod_path):
                         yield self.get_doc(dep_path)
-            routes = grow_routes.Routes.from_docs(self, _gen_docs(files))
+            routes = grow_routes.Routes.from_docs(self, _gen_docs(pod_paths))
         else:
             routes = self.get_routes()
         paths = []
@@ -237,7 +237,7 @@ class Pod(object):
             paths += items
         output = self.export_paths(
             paths, routes, suffix=suffix, append_slashes=append_slashes)
-        if not files:
+        if not pod_paths:
             error_controller = routes.match_error('/404.html')
             if error_controller:
                 output['/404.html'] = error_controller.render({})

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -227,7 +227,7 @@ class Pod(object):
             def _gen_docs(pod_paths):
                 for pod_path in pod_paths:
                     for dep_path in self.podcache.dependency_graph.get_dependents(
-                            pod_path):
+                            self._normalize_path(pod_path)):
                         yield self.get_doc(dep_path)
             routes = grow_routes.Routes.from_docs(self, _gen_docs(pod_paths))
         else:

--- a/grow/pods/routes.py
+++ b/grow/pods/routes.py
@@ -38,6 +38,14 @@ class Routes(object):
     def __iter__(self):
         return self.routing_map.iter_rules()
 
+    @staticmethod
+    def from_docs(pod, docs):
+        """Create a routes object from a set of documents."""
+        routes = Routes(pod)
+        # pylint: disable=protected-access
+        routes._build_routing_map_from_docs(docs)
+        return routes
+
     def _add_document(self, doc):
         rule, _ = self._create_rule_for_doc(doc)
         if not rule:
@@ -60,6 +68,17 @@ class Routes(object):
 
         # Static routes.
         self._routing_rules += self._build_static_routing_map_and_return_rules()
+
+        self._recreate_routing_map()
+        return self._routing_map
+
+    def _build_routing_map_from_docs(self, docs):
+        self._routing_rules = []
+
+        doc_routing_rules, new_paths_to_locales_to_docs = self._build_rules_from_docs(
+            docs)
+        self._routing_rules += doc_routing_rules
+        self._paths_to_locales_to_docs = new_paths_to_locales_to_docs
 
         self._recreate_routing_map()
         return self._routing_map

--- a/grow/pods/routes.py
+++ b/grow/pods/routes.py
@@ -92,6 +92,8 @@ class Routes(object):
         # Content documents.
         for doc in docs:
             rule, serving_path = self._create_rule_for_doc(doc)
+            if not rule:
+                continue
             if serving_path in serving_paths_to_docs:
                 duplicate_paths[serving_path].append(
                     serving_paths_to_docs[serving_path])

--- a/pylintrc
+++ b/pylintrc
@@ -6,4 +6,4 @@ max-args=10
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s).
-# disable=
+disable=logging-format-interpolation


### PR DESCRIPTION
Adds the ability to use the `--files=/content/...` flag to the build command and have it only build the content that is a dependent on the file.

Also updates the diff generated to not do deletes since there isn't enough information to know if files were deleted without a full build.

Fixes #365