### PR TITLE
Adding the ability to do glob matching for getting dependents.

### DIFF
--- a/grow/pods/dependency.py
+++ b/grow/pods/dependency.py
@@ -1,6 +1,8 @@
 """Dependency graph for content references."""
 
+import fnmatch
 import os
+
 
 class Error(Exception):
     pass
@@ -11,6 +13,7 @@ class BadFieldsError(Error, ValueError):
 
 
 class DependencyGraph(object):
+
     def __init__(self):
         self.reset()
 
@@ -63,11 +66,23 @@ class DependencyGraph(object):
         contains the reference.
         """
         return (self._dependents.get(reference, set())
-            | self._dependents.get(os.path.dirname(reference), set())
-            | set([reference]))
+                | self._dependents.get(os.path.dirname(reference), set())
+                | set([reference]))
 
     def get_dependencies(self, source):
         return self._dependencies.get(source, set())
+
+    def match_dependents(self, reference):
+        """
+        Match dependents that rely upon the reference or a collection that
+        contains the reference using a glob pattern.
+        """
+        matched_dependents = set()
+        for dependent in self._dependents:
+            if fnmatch.fnmatch(dependent, reference):
+                matched_dependents = (
+                    matched_dependents | self._dependents.get(dependent) | set([dependent]))
+        return matched_dependents
 
     def reset(self):
         self._dependents = {}

--- a/grow/pods/dependency_test.py
+++ b/grow/pods/dependency_test.py
@@ -83,11 +83,31 @@ class DependencyGraphTestCase(unittest.TestCase):
 
     def test_empty_dependents(self):
         graph = dependency.DependencyGraph()
-        self.assertEqual(set(['/content/test1.yaml']), graph.get_dependents('/content/test1.yaml'))
+        self.assertEqual(set(['/content/test1.yaml']),
+                         graph.get_dependents('/content/test1.yaml'))
 
     def test_empty_dependencies(self):
         graph = dependency.DependencyGraph()
         self.assertEqual(set(), graph.get_dependencies('/content/test.yaml'))
+
+    def test_match_dependents(self):
+        graph = dependency.DependencyGraph()
+        graph.add_references(
+            '/content/ref.yaml',
+            ['/content/test1.yaml'])
+        graph.add_references(
+            '/content/ref1.yaml',
+            ['/content/test1.yaml'])
+        graph.add_references(
+            '/content/ref2.yaml',
+            ['/content/test2.yaml'])
+        self.assertEqual(
+            set(['/content/test1.yaml', '/content/ref.yaml', '/content/ref1.yaml']),
+            graph.match_dependents('/content/test1.yaml'))
+        self.assertEqual(
+            set(['/content/test1.yaml', '/content/test2.yaml',
+                 '/content/ref.yaml', '/content/ref1.yaml', '/content/ref2.yaml']),
+            graph.match_dependents('/content/test*.yaml'))
 
     def test_reset(self):
         graph = dependency.DependencyGraph()

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -96,6 +96,13 @@ class Pod(object):
             raise ValueError('.. not allowed in file paths.')
         return os.path.join(self.root, pod_path.lstrip('/'))
 
+    def _normalize_pod_path(self, pod_path):
+        if '..' in pod_path:
+            raise ValueError('.. not allowed in pod paths.')
+        if not pod_path.startswith('/'):
+            pod_path = '/{}'.format(pod_path)
+        return pod_path
+
     def _parse_cache_yaml(self):
         podcache_file_name = '/{}'.format(self.FILE_PODCACHE)
         if not self.file_exists(podcache_file_name):
@@ -226,8 +233,8 @@ class Pod(object):
             # the docs that are dependent based on the dependecy graph.
             def _gen_docs(pod_paths):
                 for pod_path in pod_paths:
-                    for dep_path in self.podcache.dependency_graph.get_dependents(
-                            self._normalize_path(pod_path)):
+                    for dep_path in self.podcache.dependency_graph.match_dependents(
+                            self._normalize_pod_path(pod_path)):
                         yield self.get_doc(dep_path)
             routes = grow_routes.Routes.from_docs(self, _gen_docs(pod_paths))
         else:


### PR DESCRIPTION
Allows an alternative way of returning dependents by allowing for glob style matching of the dependent keys.

ex: `/content/pages/*.yaml`

Part of #484 