### PR TITLE
Dependency expanding

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -231,7 +231,6 @@ def make_yaml_loader(pod, doc=None):
         def construct_doc(self, node):
             locale = doc._locale_kwarg if doc else None
             pod_path = doc.pod_path if doc else None
-
             def func(path):
                 doc = pod.get_doc(path, locale=locale)
                 pod.podcache.dependency_graph.add(pod_path, doc.pod_path)

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -127,7 +127,7 @@ def validate_name(name):
     # TODO: better validation.
     if ('//' in name
         or '..' in name
-        or ' ' in name):
+            or ' ' in name):
         raise errors.BadNameError(
             'Names must be lowercase and only contain letters, numbers, '
             'backslashes, and dashes. Found: "{}"'.format(name))
@@ -224,11 +224,14 @@ def make_yaml_loader(pod, doc=None):
             return func(node.value)
 
         def construct_csv(self, node):
+            if doc:
+                pod.podcache.dependency_graph.add(doc.pod_path, node.value)
             return self._construct_func(node, pod.read_csv)
 
         def construct_doc(self, node):
             locale = doc._locale_kwarg if doc else None
             pod_path = doc.pod_path if doc else None
+
             def func(path):
                 doc = pod.get_doc(path, locale=locale)
                 pod.podcache.dependency_graph.add(pod_path, doc.pod_path)
@@ -239,22 +242,32 @@ def make_yaml_loader(pod, doc=None):
             return self._construct_func(node, gettext.gettext)
 
         def construct_json(self, node):
+            if doc:
+                pod.podcache.dependency_graph.add(doc.pod_path, node.value)
             return self._construct_func(node, pod.read_json)
 
         def construct_static(self, node):
             locale = doc._locale_kwarg if doc else None
-            func = lambda path: pod.get_static(path, locale=locale)
+            def func(path):
+                if doc:
+                    pod.podcache.dependency_graph.add(doc.pod_path, path)
+                return pod.get_static(path, locale=locale)
             return self._construct_func(node, func)
 
         def construct_url(self, node):
             locale = doc._locale_kwarg if doc else None
-            func = lambda path: pod.get_url(path, locale=locale)
+            def func(path):
+                if doc:
+                    pod.podcache.dependency_graph.add(doc.pod_path, path)
+                return pod.get_url(path, locale=locale)
             return self._construct_func(node, func)
 
         def construct_yaml(self, node):
             def func(path):
                 if '?' in path:
                     path, reference = path.split('?')
+                    if doc:
+                        pod.podcache.dependency_graph.add(doc.pod_path, path)
                     data = pod.read_yaml(path)
                     for key in reference.split('.'):
                         if data and key in data:
@@ -262,6 +275,8 @@ def make_yaml_loader(pod, doc=None):
                         else:
                             data = None
                     return data
+                if doc:
+                    pod.podcache.dependency_graph.add(doc.pod_path, path)
                 return pod.read_yaml(path)
             return self._construct_func(node, func)
 

--- a/grow/pods/tags.py
+++ b/grow/pods/tags.py
@@ -280,22 +280,29 @@ def create_builtin_tags(pod, doc, use_cache=False):
             return included_docs
         return _wrapper
 
+    def _wrap_dependency_path(func):
+        def _wrapper(*args, **kwargs):
+            if doc:
+                pod.podcache.dependency_graph.add(doc.pod_path, args[0])
+            return func(*args, _pod=pod, use_cache=use_cache, **kwargs)
+        return _wrapper
+
     return {
         'categories': _wrap(categories),
         'collection': _wrap(collection),
         'collections': _wrap(collections),
-        'csv': _wrap(csv),
+        'csv': _wrap_dependency_path(csv),
         'date': _wrap(date),
         'doc': _wrap_dependency(get_doc),
         'docs': _wrap_dependency(docs),
-        'json': _wrap(json),
+        'json': _wrap_dependency_path(json),
         'locale': _wrap(locale),
         'locales': _wrap(locales),
         'nav': _wrap(nav),
-        'static': _wrap(static_something),
-        'statics': _wrap(statics),
-        'url': _wrap(url),
-        'yaml': _wrap(yaml),
+        'static': _wrap_dependency(static_something),
+        'statics': _wrap_dependency(statics),
+        'url': _wrap_dependency_path(url),
+        'yaml': _wrap_dependency_path(yaml),
     }
 
 


### PR DESCRIPTION
When working with yaml constructors or the jinja functions these changes add more of the dependencies, such as `csv`, `json`, `yaml`, and static files.

Fixes #482 