### PR TITLE
Modifying deploy command to optionally abort on missing translations.

### DIFF
--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -51,7 +51,8 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
         paths_to_contents = deployment.dump(pod)
         if prevent_untranslated and pod.translation_stats.untranslated:
             pod.translation_stats.pretty_print()
-            raise pods.Error('Aborted deploy due to untranslated strings.')
+            raise pods.Error('Aborted deploy due to untranslated strings. '
+                             'Use the --force-untranslated flag to force deployment.')
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
         deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,

--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -20,7 +20,7 @@ class Config(messages.Message):
     redirect_trailing_slashes = messages.BooleanField(6, default=True)
     index_document = messages.StringField(7, default='index.html')
     error_document = messages.StringField(8, default='404.html')
-
+    base_config = messages.MessageField(base.BaseConfig, 9)
 
 
 class AmazonS3Destination(base.BaseDestination):

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -79,6 +79,7 @@ from grow.common import utils
 from grow.deployments import indexes
 from grow.deployments import tests
 from grow.pods import env
+from protorpc import messages as proto_messages
 from . import messages
 
 
@@ -112,6 +113,10 @@ class DestinationTestCase(object):
                 yield func
 
 
+class BaseConfig(proto_messages.Message):
+    prevent_untranslated = proto_messages.BooleanField(1, default=False)
+
+
 class BaseDestination(object):
     TestCase = DestinationTestCase
     diff_basename = 'diff.proto.json'
@@ -140,6 +145,13 @@ class BaseDestination(object):
         if self._has_custom_control_dir:
             return self.config.control_dir
         return self._control_dir
+
+    @property
+    def prevent_untranslated(self):
+        """Configuration for untranslated messages preventing deployment."""
+        if not self.config.base_config:
+            return False
+        return self.config.base_config.prevent_untranslated
 
     @property
     def storage(self):

--- a/grow/deployments/destinations/git_destination.py
+++ b/grow/deployments/destinations/git_destination.py
@@ -21,6 +21,7 @@ class Config(messages.Message):
     branch = messages.StringField(3, default='master')
     root_dir = messages.StringField(4, default='')
     keep_control_dir = messages.BooleanField(5, default=False)
+    base_config = messages.MessageField(base.BaseConfig, 6)
 
 
 class GitDestination(base.BaseDestination):

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -42,7 +42,7 @@ class Config(messages.Message):
     not_found_page = messages.StringField(11, default='404.html')
     oauth2 = messages.BooleanField(12, default=False)
     headers = messages.MessageField(HeaderMessage, 13, repeated=True)
-
+    base_config = messages.MessageField(base.BaseConfig, 14)
 
 
 class GoogleCloudStorageDestination(base.BaseDestination):

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -12,6 +12,7 @@ class Config(messages.Message):
     before_deploy = messages.StringField(4, repeated=True)
     after_deploy = messages.StringField(5, repeated=True)
     control_dir = messages.StringField(6)
+    base_config = messages.MessageField(base.BaseConfig, 7)
 
 
 class LocalDestination(base.BaseDestination):

--- a/grow/deployments/destinations/scp.py
+++ b/grow/deployments/destinations/scp.py
@@ -19,6 +19,7 @@ class Config(messages.Message):
     username = messages.StringField(4)
     env = messages.MessageField(env.EnvConfig, 5)
     keep_control_dir = messages.BooleanField(6, default=False)
+    base_config = messages.MessageField(base.BaseConfig, 7)
 
 
 class ScpDestination(base.BaseDestination):

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -24,6 +24,7 @@ class Config(messages.Message):
     remote = messages.StringField(8)
     subdomain = messages.StringField(9)
     subdomain_prefix = messages.StringField(10)
+    base_config = messages.MessageField(base.BaseConfig, 11)
 
 
 class WebReviewDestination(base.BaseDestination):


### PR DESCRIPTION
Uses a setting as part of the `podspec` for the deployment to mark the deployment as requiring all used strings to have translations.