### PR TITLE
Switch deploy blocking to be run from localization setting

### DIFF
--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -20,7 +20,6 @@ class Config(messages.Message):
     redirect_trailing_slashes = messages.BooleanField(6, default=True)
     index_document = messages.StringField(7, default='index.html')
     error_document = messages.StringField(8, default='404.html')
-    base_config = messages.MessageField(base.BaseConfig, 9)
 
 
 class AmazonS3Destination(base.BaseDestination):

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -113,10 +113,6 @@ class DestinationTestCase(object):
                 yield func
 
 
-class BaseConfig(proto_messages.Message):
-    prevent_untranslated = proto_messages.BooleanField(1, default=False)
-
-
 class BaseDestination(object):
     TestCase = DestinationTestCase
     diff_basename = 'diff.proto.json'

--- a/grow/deployments/destinations/git_destination.py
+++ b/grow/deployments/destinations/git_destination.py
@@ -21,7 +21,6 @@ class Config(messages.Message):
     branch = messages.StringField(3, default='master')
     root_dir = messages.StringField(4, default='')
     keep_control_dir = messages.BooleanField(5, default=False)
-    base_config = messages.MessageField(base.BaseConfig, 6)
 
 
 class GitDestination(base.BaseDestination):

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -42,7 +42,6 @@ class Config(messages.Message):
     not_found_page = messages.StringField(11, default='404.html')
     oauth2 = messages.BooleanField(12, default=False)
     headers = messages.MessageField(HeaderMessage, 13, repeated=True)
-    base_config = messages.MessageField(base.BaseConfig, 14)
 
 
 class GoogleCloudStorageDestination(base.BaseDestination):

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -12,7 +12,6 @@ class Config(messages.Message):
     before_deploy = messages.StringField(4, repeated=True)
     after_deploy = messages.StringField(5, repeated=True)
     control_dir = messages.StringField(6)
-    base_config = messages.MessageField(base.BaseConfig, 7)
 
 
 class LocalDestination(base.BaseDestination):

--- a/grow/deployments/destinations/scp.py
+++ b/grow/deployments/destinations/scp.py
@@ -19,7 +19,6 @@ class Config(messages.Message):
     username = messages.StringField(4)
     env = messages.MessageField(env.EnvConfig, 5)
     keep_control_dir = messages.BooleanField(6, default=False)
-    base_config = messages.MessageField(base.BaseConfig, 7)
 
 
 class ScpDestination(base.BaseDestination):

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -24,7 +24,6 @@ class Config(messages.Message):
     remote = messages.StringField(8)
     subdomain = messages.StringField(9)
     subdomain_prefix = messages.StringField(10)
-    base_config = messages.MessageField(base.BaseConfig, 11)
 
 
 class WebReviewDestination(base.BaseDestination):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -131,7 +131,7 @@ class Pod(object):
             raise podspec.PodSpecParseError('Error parsing: {}'.format(path))
 
     def set_env(self, env):
-        if env.name:
+        if env and env.name:
             untag = document_fields.DocumentFields.untag
             content = untag(self._parse_yaml(), env_name=env.name)
             self._yaml = content


### PR DESCRIPTION
Instead of having the blocking for deploy as part of the deploy config, switch it to be part of the `localization` area where it makes more sense.