### PR TITLE
Adding the ability to track jinja template dependencies.

### DIFF
--- a/grow/pods/dependency.py
+++ b/grow/pods/dependency.py
@@ -20,7 +20,7 @@ class DependencyGraph(object):
     @staticmethod
     def normalize_path(pod_path):
         """Normalize a pod path."""
-        if not pod_path.startswith('/'):
+        if pod_path and not pod_path.startswith('/'):
             pod_path = '/{}'.format(pod_path)
         return pod_path
 

--- a/grow/pods/dependency.py
+++ b/grow/pods/dependency.py
@@ -17,6 +17,13 @@ class DependencyGraph(object):
     def __init__(self):
         self.reset()
 
+    @staticmethod
+    def normalize_path(pod_path):
+        """Normalize a pod path."""
+        if not pod_path.startswith('/'):
+            pod_path = '/{}'.format(pod_path)
+        return pod_path
+
     def add_all(self, path_to_dependencies):
         """Add all from a dict of paths to dependencies."""
 
@@ -27,6 +34,9 @@ class DependencyGraph(object):
         """Add reference made in a source file to the graph."""
         if not reference:
             return
+
+        source = DependencyGraph.normalize_path(source)
+        reference = DependencyGraph.normalize_path(reference)
 
         if source not in self._dependencies:
             self._dependencies[source] = set()
@@ -42,10 +52,13 @@ class DependencyGraph(object):
         if not references:
             return
 
+        source = DependencyGraph.normalize_path(source)
+
         self._dependencies[source] = set(references)
 
         # Bi-directional dependency references for easier lookup.
         for reference in references:
+            reference = DependencyGraph.normalize_path(reference)
             if reference not in self._dependents:
                 self._dependents[reference] = set()
             self._dependents[reference].add(source)

--- a/grow/pods/dependency_test.py
+++ b/grow/pods/dependency_test.py
@@ -30,6 +30,19 @@ class DependencyGraphTestCase(unittest.TestCase):
             },
             graph.export())
 
+    def test_add_normalize(self):
+        graph = dependency.DependencyGraph()
+        graph.add('/content/test.yaml', 'content/test1.yaml')
+        graph.add('content/test.yaml', '/content/test2.yaml')
+        self.assertEqual(
+            {
+                '/content/test.yaml': [
+                    '/content/test1.yaml',
+                    '/content/test2.yaml',
+                ],
+            },
+            graph.export())
+
     def test_export(self):
         graph = dependency.DependencyGraph()
         graph.add_references(

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -16,6 +16,7 @@ from grow.common import sdk_utils
 from grow.common import progressbar_non
 from grow.common import utils
 from grow.preprocessors import preprocessors
+from grow.templates import template_dependencies
 from grow.translators import translation_stats
 from grow.translators import translators
 from . import catalog_holder
@@ -431,7 +432,7 @@ class Pod(object):
         if self.env.cached:
             kwargs['bytecode_cache'] = self._get_bytecode_cache()
         kwargs['extensions'].extend(self.list_jinja_extensions())
-        env = jinja2.Environment(**kwargs)
+        env = template_dependencies.DepEnvironment(**kwargs)
         env.filters.update(tags.create_builtin_filters())
         get_gettext_func = self.catalogs.get_gettext_translations
         # pylint: disable=no-member

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -67,7 +67,6 @@ class RenderedController(controllers.BaseController):
             translator = self.pod.inject_translators(doc=doc)
         jinja_env = self.pod.get_jinja_env(self.locale)
         template = jinja_env.get_template(self.view.lstrip('/'))
-
         local_tags = tags.create_builtin_tags(self.pod, doc)
         # NOTE: This should be done using get_template(... globals=...) but
         # it is not available included inside macros???

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -65,10 +65,10 @@ class RenderedController(controllers.BaseController):
         if inject:
             preprocessor = self.pod.inject_preprocessors(doc=doc)
             translator = self.pod.inject_translators(doc=doc)
-        env = self.pod.get_jinja_env(self.locale)
+        jinja_env = self.pod.get_jinja_env(self.locale)
+        template = jinja_env.get_template(self.view.lstrip('/'))
 
         local_tags = tags.create_builtin_tags(self.pod, doc)
-        template = env.get_template(self.view.lstrip('/'))
         # NOTE: This should be done using get_template(... globals=...) but
         # it is not available included inside macros???
         # See: https://github.com/pallets/jinja/issues/688

--- a/grow/pods/tags.py
+++ b/grow/pods/tags.py
@@ -4,10 +4,10 @@ import collections as py_collections
 from datetime import datetime
 import itertools
 import json as json_lib
+import random
 import re
 import jinja2
 import markdown
-import random
 from babel import dates as babel_dates
 from babel import numbers as babel_numbers
 from grow.common import json_encoder
@@ -212,6 +212,11 @@ def make_doc_gettext(doc):
     return gettext
 
 
+def track_dependency(pod_path, _pod=None):
+    """Blank method that gets wrapped for tracking template dependencies."""
+    pass
+
+
 @utils.memoize_tag
 def csv(path, locale=utils.SENTINEL, _pod=None):
     """Retrieves a csv file from the pod."""
@@ -321,6 +326,7 @@ def create_builtin_tags(pod, doc):
         'statics': _wrap_dependency(statics),
         'url': _wrap_dependency_path(url),
         'yaml': _wrap_dependency_path(yaml),
+        '_track_dependency': _wrap_dependency_path(track_dependency),
     }
 
 

--- a/grow/templates/template_dependencies.py
+++ b/grow/templates/template_dependencies.py
@@ -1,0 +1,12 @@
+"""Track the jinja2 rendering dependencies."""
+
+import jinja2
+
+class DepEnvironment(jinja2.Environment):
+    """Override to track the dependencies for the current doc."""
+
+    # pylint: disable=redefined-builtin
+    def _load_template(self, name, globals):
+        if 'g' in globals and '_track_dependency' in globals['g']:
+            globals['g']['_track_dependency'](name)
+        return super(DepEnvironment, self)._load_template(name, globals)


### PR DESCRIPTION
Uses a custom environment that adds the tracking in when the actual templates are being used during rendering. Done as a subclass of the `Environment` since a custom loader is cached in the environment and wouldn't show all of the templates used.