### PR TITLE
Document Translation Stats

### DIFF
--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -1,16 +1,19 @@
-from . import document_fields
-from . import document_format
-from . import footnotes
-from . import locales
-from . import messages
-from . import urls
-from grow.common import utils
+"""Grow documents."""
+
 import datetime
 import json
 import logging
 import os
 import re
 import yaml
+from grow.common import utils
+from grow.translators import translation_stats
+from . import document_fields
+from . import document_format
+from . import footnotes
+from . import locales
+from . import messages
+from . import urls
 
 
 PATH_LOCALE_REGEX = re.compile(r'@([^-_]+)([-_]?)([^\.]*)(\.[^\.]+)$')
@@ -318,6 +321,10 @@ class Document(object):
     @property
     def title(self):
         return self.fields.get('$title')
+
+    @utils.cached_property
+    def translation_stats(self):
+        return translation_stats.TranslationStats()
 
     @property
     def url(self):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -16,6 +16,7 @@ from grow.common import sdk_utils
 from grow.common import progressbar_non
 from grow.common import utils
 from grow.preprocessors import preprocessors
+from grow.templates import tags
 from grow.templates import template_dependencies
 from grow.translators import translation_stats
 from grow.translators import translators
@@ -30,7 +31,6 @@ from . import podspec
 from . import routes as grow_routes
 from . import static as grow_static
 from . import storage as grow_storage
-from . import tags
 
 
 class Error(Exception):

--- a/grow/pods/rendered.py
+++ b/grow/pods/rendered.py
@@ -2,11 +2,11 @@
 
 import mimetypes
 import sys
+from grow.templates import tags
 from . import controllers
 from . import env
 from . import errors
 from . import messages
-from . import tags
 from . import ui
 
 

--- a/grow/pods/ui.py
+++ b/grow/pods/ui.py
@@ -1,8 +1,10 @@
+"""Grow UI Tools"""
+
+import os
+import jinja2
 from grow.common import utils
 from grow.pods.storage import storage
-from grow.pods import tags
-import jinja2
-import os
+from grow.templates import tags
 
 
 @utils.memoize

--- a/grow/templates/tags.py
+++ b/grow/templates/tags.py
@@ -12,9 +12,9 @@ from babel import dates as babel_dates
 from babel import numbers as babel_numbers
 from grow.common import json_encoder
 from grow.common import utils
+from grow.pods import collection as collection_lib
 from grow.pods import locales as locales_lib
 from grow.pods import urls
-from . import collection as collection_lib
 
 
 SLUG_REGEX = re.compile(r'[^A-Za-z0-9-._~]+')

--- a/grow/templates/tags_test.py
+++ b/grow/templates/tags_test.py
@@ -1,9 +1,11 @@
-from . import tags
+"""Tests for the template tags and filters."""
+
+import unittest
 from grow.pods import locales
 from grow.pods import pods
 from grow.pods import storage
+from grow.templates import tags
 from grow.testing import testing
-import unittest
 
 
 class BuiltinsTestCase(unittest.TestCase):


### PR DESCRIPTION
Adding the ability to have per document translation stats during the build. This is in addition to the pod wide translation stats.

Also moved the tags file over to the `templates` directory.