### PR TITLE
Streaming Pod Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
   then brew unlink python;
   brew install python;
-  pip install -U virtualenv;
+  pip2 install -U virtualenv;
   fi
 - pip2 install -U pip
 - pip2 install -r requirements-dev.txt

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -38,11 +38,11 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths, locate_untransl
         config = local_destination.Config(out_dir=out_dir)
         destination = local_destination.LocalDestination(config)
         destination.pod = pod
-        paths_to_contents = destination.dump(pod, pod_paths=pod_paths)
         repo = utils.get_git_repo(pod.root)
-        stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
-        destination.deploy(paths_to_contents, stats=stats_obj, repo=repo, confirm=False,
-                           test=False, is_partial=bool(pod_paths))
+        # stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
+        stats_obj = None
+        destination.deploy_stream(destination.dump_stream(pod, pod_paths=pod_paths),
+            stats=stats_obj, repo=repo, confirm=False, test=False, is_partial=bool(pod_paths))
         pod.podcache.write()
     except pods.Error as err:
         raise click.ClickException(str(err))

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -38,11 +38,12 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths, locate_untransl
         config = local_destination.Config(out_dir=out_dir)
         destination = local_destination.LocalDestination(config)
         destination.pod = pod
+        paths, _ = pod.determine_paths(pod_paths=pod_paths)
         repo = utils.get_git_repo(pod.root)
-        # stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
-        stats_obj = None
-        destination.deploy_stream(destination.dump_stream(pod, pod_paths=pod_paths),
-            stats=stats_obj, repo=repo, confirm=False, test=False, is_partial=bool(pod_paths))
+        stats_obj = stats.Stats(pod, paths=paths)
+        content_generator = destination.dump(pod, pod_paths=pod_paths)
+        destination.deploy(content_generator, stats=stats_obj, repo=repo, confirm=False,
+                           test=False, is_partial=bool(pod_paths))
         pod.podcache.write()
     except pods.Error as err:
         raise click.ClickException(str(err))

--- a/grow/commands/build.py
+++ b/grow/commands/build.py
@@ -38,7 +38,7 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths, locate_untransl
         config = local_destination.Config(out_dir=out_dir)
         destination = local_destination.LocalDestination(config)
         destination.pod = pod
-        paths, _ = pod.determine_paths(pod_paths=pod_paths)
+        paths, _ = pod.determine_paths_to_build(pod_paths=pod_paths)
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths=paths)
         content_generator = destination.dump(pod, pod_paths=pod_paths)

--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -50,7 +50,7 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
             return
         content_generator = deployment.dump(pod)
         repo = utils.get_git_repo(pod.root)
-        paths, _ = pod.determine_paths()
+        paths, _ = pod.determine_paths_to_build()
         stats_obj = stats.Stats(pod, paths=paths)
         deployment.deploy(content_generator, stats=stats_obj, repo=repo,
                           confirm=confirm, test=test, require_translations=require_translations)

--- a/grow/commands/deploy.py
+++ b/grow/commands/deploy.py
@@ -41,8 +41,6 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
         require_translations = pod.podspec.localization.get(
             'require_translations', False)
         require_translations = require_translations and not force_untranslated
-        if require_translations:
-            pod.enable(pod.FEATURE_TRANSLATION_STATS)
         if auth:
             deployment.login(auth)
         if preprocess:
@@ -50,16 +48,13 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
         if test_only:
             deployment.test()
             return
-        paths_to_contents = deployment.dump(pod)
-        if require_translations and pod.translation_stats.untranslated:
-            pod.translation_stats.pretty_print()
-            raise pods.Error('Aborted deploy due to untranslated strings. '
-                             'Use the --force-untranslated flag to force deployment.')
+        content_generator = deployment.dump(pod)
         repo = utils.get_git_repo(pod.root)
-        stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
-        deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,
-                          confirm=confirm, test=test)
-    except base.Error as e:
-        raise click.ClickException(str(e))
-    except pods.Error as e:
-        raise click.ClickException(str(e))
+        paths, _ = pod.determine_paths()
+        stats_obj = stats.Stats(pod, paths=paths)
+        deployment.deploy(content_generator, stats=stats_obj, repo=repo,
+                          confirm=confirm, test=test, require_translations=require_translations)
+    except base.Error as err:
+        raise click.ClickException(str(err))
+    except pods.Error as err:
+        raise click.ClickException(str(err))

--- a/grow/commands/stage.py
+++ b/grow/commands/stage.py
@@ -41,7 +41,7 @@ def stage(context, pod_path, remote, preprocess, subdomain, api_key, force_untra
             pod.preprocess()
         content_generator = deployment.dump(pod)
         repo = utils.get_git_repo(pod.root)
-        paths, _ = pod.determine_paths()
+        paths, _ = pod.determine_paths_to_build()
         stats_obj = stats.Stats(pod, paths=paths)
         deployment.deploy(content_generator, stats=stats_obj, repo=repo,
                           confirm=False, test=False, require_translations=require_translations)

--- a/grow/deployments/destinations/git_destination_test.py
+++ b/grow/deployments/destinations/git_destination_test.py
@@ -28,10 +28,12 @@ class GitDestinationTestCase(unittest.TestCase):
         })
         pod.write_file('/views/base.html', str(random.randint(0, 999)))
         deployment = pod.get_deployment('git')
-        paths_to_contents = deployment.dump(pod)
+        paths = []
+        for path, _ in deployment.dump(pod):
+            paths.append(path)
         repo = utils.get_git_repo(pod.root)
-        stats_obj = stats.Stats(pod, paths_to_contents=paths_to_contents)
-        deployment.deploy(paths_to_contents, stats=stats_obj, repo=repo,
+        stats_obj = stats.Stats(pod, paths=paths)
+        deployment.deploy(deployment.dump(pod), stats=stats_obj, repo=repo,
                           confirm=False, test=False)
 
     def test_deploy_local(self):

--- a/grow/deployments/indexes_test.py
+++ b/grow/deployments/indexes_test.py
@@ -22,11 +22,9 @@ class IndexTest(unittest.TestCase):
           '/file.txt': 'test',
           '/file2.txt': 'test',
           '/foo/file.txt': 'test',
-          '/foo/file.txt': 'test',
         })
         their_index = indexes.Index.create({
           '/file2.txt': 'change',
-          '/foo/file.txt': 'test',
           '/foo/file.txt': 'test',
           '/bar/new.txt': 'test',
         })

--- a/grow/deployments/stats.py
+++ b/grow/deployments/stats.py
@@ -9,18 +9,17 @@ from . import messages
 
 class Stats(object):
 
-    def __init__(self, pod, paths_to_contents=None, full=True):
+    def __init__(self, pod, paths=None, full=True):
         self.full = full
         self.pod = pod
-        if paths_to_contents is None and full:
-            paths_to_contents = pod.export()
-        self.paths_to_contents = paths_to_contents
+        self.paths = paths
 
     def get_num_files_per_type(self):
         file_counts = collections.defaultdict(int)
-        for path in self.paths_to_contents.keys():
-            ext = os.path.splitext(path)[-1]
-            file_counts[ext] += 1
+        if self.paths:
+            for path in self.paths:
+                ext = os.path.splitext(path)[-1]
+                file_counts[ext] += 1
         ms = []
         for ext, count in file_counts.iteritems():
             ms.append(messages.FileCountMessage(ext=ext, count=count))

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -234,7 +234,7 @@ class Pod(object):
             normal_paths.append(self._normalize_path(pod_path))
         return self.storage.delete_files(normal_paths, recursive=recursive, pattern=pattern)
 
-    def determine_paths(self, pod_paths=None):
+    def determine_paths_to_build(self, pod_paths=None):
         """Determines which paths are going to be built with optional path filtering."""
         if pod_paths:
             # When provided a list of pod_paths do a custom routing tree based on
@@ -268,7 +268,7 @@ class Pod(object):
 
     def export(self, suffix=None, append_slashes=False, pod_paths=None):
         """Builds the pod, returning a mapping of paths to content based on pod routes."""
-        paths, routes = self.determine_paths(pod_paths=pod_paths)
+        paths, routes = self.determine_paths_to_build(pod_paths=pod_paths)
         for output_path, rendered in self.render_paths(
                 paths, routes, suffix=suffix, append_slashes=append_slashes):
             yield output_path, rendered

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -306,8 +306,8 @@ class Pod(object):
 
         text = 'Building UI Tools: %(value)d/{} (in %(seconds_elapsed)s)'
         widgets = [progressbar.FormatLabel(text.format(len(paths)))]
-        progress = progressbar_non.create_progressbar("Building UI Tools...",
-                                                      widgets=widgets, max_value=len(paths))
+        progress = progressbar_non.create_progressbar(
+            "Building UI Tools...", widgets=widgets, max_value=len(paths))
         progress.start()
         for path in paths:
             output_path = path.replace(
@@ -683,8 +683,8 @@ class Pod(object):
         """Builds the pod, returning a mapping of paths to content."""
         text = 'Building: %(value)d/{} (in %(seconds_elapsed)s)'
         widgets = [progressbar.FormatLabel(text.format(len(paths)))]
-        bar = progressbar_non.create_progressbar("Building pod...",
-                                                 widgets=widgets, max_value=len(paths))
+        bar = progressbar_non.create_progressbar(
+            "Building pod...", widgets=widgets, max_value=len(paths))
         bar.start()
         for path in paths:
             output_path = path

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -680,7 +680,7 @@ class Pod(object):
         return untag(fields, env_name=self.env.name)
 
     def render_paths(self, paths, routes, suffix=None, append_slashes=False):
-        """Builds the pod, returning a mapping of paths to content."""
+        """Renders the given paths and yields each path and content."""
         text = 'Building: %(value)d/{} (in %(seconds_elapsed)s)'
         widgets = [progressbar.FormatLabel(text.format(len(paths)))]
         bar = progressbar_non.create_progressbar(

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -55,7 +55,8 @@ class PodTest(unittest.TestCase):
         self.pod.list_collections()
 
     def test_export(self):
-        self.pod.export()
+        for _ in self.pod.export():
+            pass
 
     def test_dump(self):
         paths = [
@@ -128,7 +129,9 @@ class PodTest(unittest.TestCase):
             '/json_test/index.html',
             '/yaml_test/index.html',
         ]
-        result = self.pod.dump()
+        result = {}
+        for path, rendered in self.pod.dump():
+            result[path] = rendered
         self.assertItemsEqual(paths, result)
 
     def test_to_message(self):
@@ -227,7 +230,9 @@ class PodTest(unittest.TestCase):
             '/static/file.txt',
             '/static/extensionless',
         ]
-        paths = pod.dump().keys()
+        paths = []
+        for path, _ in pod.dump():
+            paths.append(path)
         self.assertItemsEqual(expected, paths)
 
         # Verify export does not append suffix.
@@ -236,7 +241,9 @@ class PodTest(unittest.TestCase):
             '/static/file.txt',
             '/static/extensionless',
         ]
-        paths = pod.export().keys()
+        paths = []
+        for path, _ in pod.export():
+            paths.append(path)
         self.assertItemsEqual(expected, paths)
 
 

--- a/grow/pods/sitemap_test.py
+++ b/grow/pods/sitemap_test.py
@@ -81,7 +81,9 @@ class SitemapTest(unittest.TestCase):
             '$title': 'Foo',
         })
         pod.write_file('/views/base.html', '{{doc.html}}')
-        paths_to_contents = pod.export()
+        paths_to_contents = {}
+        for path, content in pod.export():
+            paths_to_contents[path] = content
         content = paths_to_contents['/sitemap.xml']
         self.assertEqual(content, 'foo')
 


### PR DESCRIPTION
Adding  'streaming' build for the pod. Instead of rendering all the paths into a full object, this changes the `export` and `dump` methods to use a generator to render the documents.

The diff and index building are also updated to work with the streaming content. The content is only stored when it is different from the existing content. This should use a lot less overall memory on large sites.