### PR TITLE
Adding a `locale_safe` property to the document.

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -240,13 +240,13 @@ def make_yaml_loader(pod, doc=None):
             return self._construct_func(node, pod.read_csv)
 
         def construct_doc(self, node):
-            locale = doc._locale_kwarg if doc else None
+            locale = str(doc.locale_safe) if doc else None
             pod_path = doc.pod_path if doc else None
 
             def func(path):
-                doc = pod.get_doc(path, locale=locale)
-                pod.podcache.dependency_graph.add(pod_path, doc.pod_path)
-                return doc
+                contructed_doc = pod.get_doc(path, locale=locale)
+                pod.podcache.dependency_graph.add(pod_path, contructed_doc.pod_path)
+                return contructed_doc
             return self._construct_func(node, func)
 
         def construct_gettext(self, node):
@@ -258,7 +258,7 @@ def make_yaml_loader(pod, doc=None):
             return self._construct_func(node, pod.read_json)
 
         def construct_static(self, node):
-            locale = doc._locale_kwarg if doc else None
+            locale = str(doc.locale_safe) if doc else None
 
             def func(path):
                 if doc:
@@ -272,11 +272,9 @@ def make_yaml_loader(pod, doc=None):
                     return None
                 main, reference = path.split('.', 1)
                 path = '/content/strings/{}.yaml'.format(main)
-                locale = None
+                locale = str(doc.locale_safe) if doc else None
                 if doc:
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
-                    locale = str(
-                        doc._locale_kwarg or doc.collection.default_locale)
                 if reference:
                     # TODO: This is not using any cache...
                     data = pod.read_yaml(path, locale=locale)
@@ -285,7 +283,7 @@ def make_yaml_loader(pod, doc=None):
             return self._construct_func(node, func)
 
         def construct_url(self, node):
-            locale = doc._locale_kwarg if doc else None
+            locale = str(doc.locale_safe) if doc else None
 
             def func(path):
                 if doc:
@@ -297,11 +295,9 @@ def make_yaml_loader(pod, doc=None):
             def func(path):
                 if '?' in path:
                     path, reference = path.split('?')
-                    locale = None
+                    locale = str(doc.locale_safe) if doc else None
                     if doc:
                         pod.podcache.dependency_graph.add(doc.pod_path, path)
-                        locale = str(
-                            doc._locale_kwarg or doc.collection.default_locale)
                     # TODO: This is not using any cache...
                     data = pod.read_yaml(path, locale=locale)
                     return YamlLoader.deep_reference(reference, data)

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -218,7 +218,7 @@ class Document(object):
 
     @utils.cached_property
     def fields(self):
-        locale_identifier = str(self.locale_safe)
+        locale_identifier = str(self._locale_kwarg or self.default_locale)
         return document_fields.DocumentFields(
             self.format.front_matter.data, locale_identifier,
             env_name=self.pod.env.name)

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -218,7 +218,7 @@ class Document(object):
 
     @utils.cached_property
     def fields(self):
-        locale_identifier = str(self._locale_kwarg or self.default_locale)
+        locale_identifier = str(self.locale_safe)
         return document_fields.DocumentFields(
             self.format.front_matter.data, locale_identifier,
             env_name=self.pod.env.name)
@@ -258,6 +258,14 @@ class Document(object):
         if self._locale is utils.SENTINEL:
             self._locale = self._init_locale(self._locale_kwarg, self.pod_path)
         return self._locale
+
+    @utils.cached_property
+    def locale_safe(self):
+        # During the initialization of the document the locale is used,
+        # but the fields cannot be used to modify the locale. This is a 'safe'
+        # way of getting the locale defined in the constructor with a fallback
+        # to the collection default locale.
+        return self._locale_kwarg or self.collection.default_locale
 
     @utils.cached_property
     def locale_paths(self):


### PR DESCRIPTION
This is a 'safe' way to reference what the locale of the document should be. It does not take into account any custom locale information defined in the front matter.

If it tries to use the normal `document.locale` while loading front-matter (such as `!g.doc`) it causes an infinite loop to use the `doc.locale.` There was a bug when just using the kwarg for the locale so this property uses the kwarg or falls back to the collection default.