### PR TITLE
Updating the untagging to support a params object.

### DIFF
--- a/grow/pods/collection.py
+++ b/grow/pods/collection.py
@@ -113,7 +113,8 @@ class Collection(object):
         """Creates a new collection by writing a blueprint."""
         collection = cls.get(collection_path, pod)
         if collection.exists:
-            raise CollectionExistsError('{} already exists.'.format(collection))
+            raise CollectionExistsError(
+                '{} already exists.'.format(collection))
         fields = utils.dump_yaml(fields)
         pod.write_file(collection.blueprint_path, fields)
         return collection
@@ -155,7 +156,7 @@ class Collection(object):
     @utils.cached_property
     def fields(self):
         untag = document_fields.DocumentFields.untag
-        fields = untag(self.tagged_fields, env_name=self.pod.env.name)
+        fields = untag(self.tagged_fields, params={'env': self.pod.env.name})
         return {} if not fields else fields
 
     @utils.cached_property
@@ -269,7 +270,8 @@ class Collection(object):
             injected_docs = self.pod.inject_preprocessors(collection=self)
             if injected_docs is not None:
                 sorted_docs = injected_docs
-                self.pod.logger.info('Injected collection -> {}'.format(self.pod_path))
+                self.pod.logger.info(
+                    'Injected collection -> {}'.format(self.pod_path))
             return reversed(sorted_docs) if reverse else sorted_docs
         for path in self.pod.list_dir(self.pod_path, recursive=recursive):
             pod_path = os.path.join(self.pod_path, path.lstrip('/'))
@@ -287,7 +289,8 @@ class Collection(object):
                 if locale_from_path:
                     if (locale is not None
                             and locale in [utils.SENTINEL, locale_from_path]):
-                        new_doc = self.get_doc(pod_path, locale=locale_from_path)
+                        new_doc = self.get_doc(
+                            pod_path, locale=locale_from_path)
                         if not include_hidden and new_doc.hidden:
                             continue
                         sorted_docs.insert(new_doc)
@@ -302,7 +305,8 @@ class Collection(object):
                 if locale == doc.default_locale:
                     sorted_docs.insert(doc)
                 else:
-                    self._add_localized_docs(sorted_docs, pod_path, locale, doc)
+                    self._add_localized_docs(
+                        sorted_docs, pod_path, locale, doc)
             except Exception as e:
                 logging.error('Error loading doc: {}'.format(pod_path))
                 raise
@@ -314,10 +318,11 @@ class Collection(object):
     docs = list_docs
 
     def list_servable_documents(self, include_hidden=False, locales=None,
-            inject=None, doc_list=None):
+                                inject=None, doc_list=None):
         if not doc_list:
             inject = False if inject is None else inject
-            doc_list = self.list_docs(include_hidden=include_hidden, inject=inject)
+            doc_list = self.list_docs(
+                include_hidden=include_hidden, inject=inject)
         docs = []
         for doc in doc_list:
             if (self._get_builtin_field('draft')
@@ -339,7 +344,7 @@ class Collection(object):
         return docs
 
     def list_servable_document_locales(self, pod_path, include_hidden=False,
-            locales=None):
+                                       locales=None):
         sorted_docs = structures.SortedCollection(key=None)
         doc = self.get_doc(pod_path)
         sorted_docs.insert(doc)

--- a/grow/pods/document_fields.py
+++ b/grow/pods/document_fields.py
@@ -47,7 +47,6 @@ class DocumentFields(object):
             if params:
                 param_regex = re.compile(
                     r'(.*)@({})\.([^@]+)$'.format('|'.join(params.keys())))
-                print param_regex.pattern
                 param_match = param_regex.match(key)
                 if param_match:
                     untagged_key, param_key, param_value = param_match.groups()

--- a/grow/pods/document_fields.py
+++ b/grow/pods/document_fields.py
@@ -4,8 +4,7 @@ from boltons import iterutils
 import re
 
 
-ENV_KEY_REGEX = re.compile('(.*)@env\.([^@]+)$')
-LOCALIZED_KEY_REGEX = re.compile('(.*)@([^@]+)$')
+LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)$')
 
 
 class DocumentFields(object):
@@ -16,21 +15,23 @@ class DocumentFields(object):
     def __getitem__(self, key):
         return self._data[key]
 
-    def __init__(self, data, locale_identifier=None, env_name=None):
+    def __init__(self, data, locale_identifier=None, params=None):
         self._locale_identifier = locale_identifier
-        self._env_name = env_name
-        self._data = DocumentFields.untag(data, locale_identifier, env_name)
+        self._params = params
+        self._data = DocumentFields.untag(
+            data, locale_identifier, params=params)
 
     def __len__(self):
         return len(self._data)
 
     @staticmethod
-    def untag(data, locale=None, env_name=None):
+    def untag(data, locale=None, params=None):
         """Untags fields, handling translation priority."""
         updated_localized_paths = set()
         paths_to_keep_tagged = set()
 
         def visit(path, key, value):
+            """Function for each key and value in the data."""
             if not isinstance(key, basestring):
                 return key, value
             if (path, key.rstrip('@')) in updated_localized_paths:
@@ -41,15 +42,21 @@ class DocumentFields(object):
                 if isinstance(value, list):
                     paths_to_keep_tagged.add((path, key))
                 key = key[:-1]
-            # Support <key>@env.<name regex>: <value>.
-            env_match = ENV_KEY_REGEX.match(key)
-            if env_match:
-                untagged_key, env_name_from_key = env_match.groups()
-                env_regex = r'^{}$'.format(env_name_from_key)
-                if not env_name or not re.match(env_regex, env_name):
-                    return False
-                updated_localized_paths.add((path, untagged_key.rstrip('@')))
-                return untagged_key, value
+
+            # Support <key>@<param key>.<param value>: <value>.
+            if params:
+                param_regex = re.compile(
+                    r'(.*)@({})\.([^@]+)$'.format('|'.join(params.keys())))
+                print param_regex.pattern
+                param_match = param_regex.match(key)
+                if param_match:
+                    untagged_key, param_key, param_value = param_match.groups()
+                    param_value_regex = r'^{}$'.format(param_value)
+                    if not params[param_key] or not re.match(param_value_regex, params[param_key]):
+                        return False
+                    updated_localized_paths.add((path, untagged_key.rstrip('@')))
+                    return untagged_key, value
+
             # Support <key>@<locale regex>: <value>.
             match = LOCALIZED_KEY_REGEX.match(key)
             if not match:
@@ -88,5 +95,5 @@ class DocumentFields(object):
 
     def update(self, updated):
         updated = DocumentFields.untag(
-            updated, self._locale_identifier, self._env_name)
+            updated, self._locale_identifier, params=self._params)
         self._data.update(updated)

--- a/grow/pods/document_fields_test.py
+++ b/grow/pods/document_fields_test.py
@@ -69,8 +69,8 @@ class DocumentFieldsTestCase(unittest.TestCase):
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'title': 'value-fr',
-            'list': [{'list-item-title': 'value-fr'},],
-            'nested': {'nested-title': 'nested-value-fr',},
+            'list': [{'list-item-title': 'value-fr'}, ],
+            'nested': {'nested-title': 'nested-value-fr', },
             'sub-nested': {
                 'sub-nested': {
                     'nested': 'sub-sub-nested-value',
@@ -81,7 +81,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'title': 'value-none',
-            'list': ['list-item-de',],
+            'list': ['list-item-de', ],
             'nested': {
                 'nested-none': 'nested-value-none',
                 'nested-title': 'nested-value-none',
@@ -492,7 +492,7 @@ class DocumentFieldsTestCase(unittest.TestCase):
             },
         }, document_fields.DocumentFields.untag(fields, locale='de_AT'))
 
-    def test_untag_env_name(self):
+    def test_untag_params(self):
         untag = document_fields.DocumentFields.untag
         fields_to_test = {
             'foo': 'base',
@@ -502,13 +502,13 @@ class DocumentFieldsTestCase(unittest.TestCase):
         fields = copy.deepcopy(fields_to_test)
         self.assertDictEqual({
             'foo': 'base',
-        }, untag(fields, locale=None, env_name=None))
+        }, untag(fields, locale=None, params={'env': None}))
         self.assertDictEqual({
             'foo': 'dev',
-        }, untag(fields, locale=None, env_name='dev'))
+        }, untag(fields, locale=None, params={'env': 'dev'}))
         self.assertDictEqual({
             'foo': 'prod',
-        }, untag(fields, locale=None, env_name='prod'))
+        }, untag(fields, locale=None, params={'env': 'prod'}))
         fields_to_test = {
             'nested': {
                 'foo': 'nested-base',
@@ -524,22 +524,22 @@ class DocumentFieldsTestCase(unittest.TestCase):
             'nested': {
                 'foo': 'nested-base',
             },
-        }, untag(fields, locale=None, env_name=None))
+        }, untag(fields, locale=None, params={'env': None}))
         self.assertDictEqual({
             'nested': {
                 'foo': 'nested-base',
             },
-        }, untag(fields, locale=None, env_name='dev'))
+        }, untag(fields, locale=None, params={'env': 'dev'}))
         self.assertDictEqual({
             'nested': {
                 'foo': 'nested-de-dev',
             },
-        }, untag(fields, locale='de', env_name='dev'))
+        }, untag(fields, locale='de', params={'env': 'dev'}))
         self.assertDictEqual({
             'nested': {
                 'foo': 'nested-de-prod',
             },
-        }, untag(fields, locale='de', env_name='prod'))
+        }, untag(fields, locale='de', params={'env': 'prod'}))
 
     def test_update(self):
         """Test that updates properly overwrite and are untagged."""

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -221,7 +221,7 @@ class Document(object):
         locale_identifier = str(self._locale_kwarg or self.default_locale)
         return document_fields.DocumentFields(
             self.format.front_matter.data, locale_identifier,
-            env_name=self.pod.env.name)
+            params={'env': self.pod.env.name})
 
     @utils.cached_property
     def footnotes(self):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -139,7 +139,7 @@ class Pod(object):
     def set_env(self, env):
         if env and env.name:
             untag = document_fields.DocumentFields.untag
-            content = untag(self._parse_yaml(), env_name=env.name)
+            content = untag(self._parse_yaml(), params={'env': env.name})
             self._yaml = content
             # Preprocessors may depend on env, reset cache.
             # pylint: disable=no-member
@@ -660,7 +660,8 @@ class Pod(object):
             for trigger_doc in trigger_docs:
                 if trigger_doc.has_serving_path():
                     try:
-                        _ = self.routes.match(trigger_doc.get_serving_path(), env=route_env)
+                        _ = self.routes.match(
+                            trigger_doc.get_serving_path(), env=route_env)
                     except webob_exc.HTTPNotFound:
                         added_docs.append(trigger_doc)
             if added_docs or removed_docs:
@@ -702,7 +703,7 @@ class Pod(object):
         fields = utils.parse_yaml(self.read_file(path), pod=self)
         try:
             untag = document_fields.DocumentFields.untag
-            return untag(fields, env_name=self.env.name, locale=locale)
+            return untag(fields, locale=locale, params={'env': self.env.name})
         except Exception as e:
             logging.error('Error parsing -> {}'.format(path))
             raise


### PR DESCRIPTION
This allows for untagging with an arbitrary set of prefixed values.

For example, `params={'env': 'prod'}` would match `key@env.prod`.

Fixes #547