### PR TITLE
File Caching for Yaml Constructors and Template Tags

### DIFF
--- a/grow/cache/file_cache.py
+++ b/grow/cache/file_cache.py
@@ -11,14 +11,21 @@ class FileCache(object):
     def __init__(self):
         self.reset()
 
-    def add(self, pod_path, value):
-        """Add a value to the cache by pod_path."""
-        self._cache[pod_path] = value
+    def _ensure_exists(self, pod_path, value=None):
+        if pod_path not in self._cache:
+            self._cache[pod_path] = value or {}
+        return self._cache[pod_path]
 
-    def add_all(self, pod_path_to_cached):
+    def add(self, pod_path, value, locale=None):
+        """Add a value to the cache by pod_path."""
+        container = self._ensure_exists(pod_path)
+        container[locale] = value
+
+    def add_all(self, pod_path_to_cached, locale=None):
         """Add a multiple values to the cache by pod_paths."""
         for pod_path, value in pod_path_to_cached.iteritems():
-            self._cache[pod_path] = value
+            container = self._ensure_exists(pod_path)
+            container[locale] = value
 
     def remove(self, pod_path):
         """Remove a value from the cache by pod_path."""
@@ -28,13 +35,10 @@ class FileCache(object):
         """Exports all the file cache data."""
         return self._cache
 
-    def get(self, pod_path):
+    def get(self, pod_path, locale=None):
         """Retrieve a cache value by pod_path or None."""
-        return self._cache.get(pod_path, None)
-
-    def path_changed(self, pod_path):
-        """Triggers that a path has changed and the value is invalid."""
-        return self.remove(pod_path)
+        container = self._ensure_exists(pod_path)
+        return container.get(locale, None)
 
     def reset(self):
         """Resets the internal cache reference."""

--- a/grow/cache/file_cache.py
+++ b/grow/cache/file_cache.py
@@ -1,8 +1,7 @@
 """
 Cache for storing and retrieving file content at a pod_path.
 
-The contents of the cache should be raw and not internationalized as it will
-be shared between locales with the same pod_path.
+The contents of the cache can be parsed and are stored based on locale.
 """
 
 class FileCache(object):

--- a/grow/cache/file_cache.py
+++ b/grow/cache/file_cache.py
@@ -1,0 +1,41 @@
+"""
+Cache for storing and retrieving file content at a pod_path.
+
+The contents of the cache should be raw and not internationalized as it will
+be shared between locales with the same pod_path.
+"""
+
+class FileCache(object):
+    """Simple cache for file contents."""
+
+    def __init__(self):
+        self.reset()
+
+    def add(self, pod_path, value):
+        """Add a value to the cache by pod_path."""
+        self._cache[pod_path] = value
+
+    def add_all(self, pod_path_to_cached):
+        """Add a multiple values to the cache by pod_paths."""
+        for pod_path, value in pod_path_to_cached.iteritems():
+            self._cache[pod_path] = value
+
+    def remove(self, pod_path):
+        """Remove a value from the cache by pod_path."""
+        return self._cache.pop(pod_path, None)
+
+    def export(self):
+        """Exports all the file cache data."""
+        return self._cache
+
+    def get(self, pod_path):
+        """Retrieve a cache value by pod_path or None."""
+        return self._cache.get(pod_path, None)
+
+    def path_changed(self, pod_path):
+        """Triggers that a path has changed and the value is invalid."""
+        return self.remove(pod_path)
+
+    def reset(self):
+        """Resets the internal cache reference."""
+        self._cache = {}

--- a/grow/cache/file_cache_test.py
+++ b/grow/cache/file_cache_test.py
@@ -13,35 +13,41 @@ class FileCacheTestCase(unittest.TestCase):
     def test_add(self):
         """Test that adding to the file cache works."""
         self.test_cache.add('/content/answer.txt', {
-            'answer': 42
+            'answer': 42,
         })
         self.assertEqual(42, self.test_cache.get('/content/answer.txt')['answer'])
 
     def test_export(self):
         """Test that exporting the file cache works."""
         self.test_cache.add('/content/answer.txt', {
-            'answer': 42
+            'answer': 42,
         })
         self.test_cache.add('/content/question.txt', {
-            'question': '???'
+            'question': '???',
         })
         self.assertDictEqual({
             '/content/question.txt': {
-                'question': '???'
+                None: {
+                    'question': '???',
+                },
             },
             '/content/answer.txt': {
-                'answer': 42
+                None: {
+                    'answer': 42,
+                },
             },
         }, self.test_cache.export())
 
     def test_remove(self):
         """Test that paths can be removed from the cache."""
         self.test_cache.add('/content/answer.txt', {
-            'answer': 42
+            'answer': 42,
         })
         self.assertEqual(42, self.test_cache.get('/content/answer.txt')['answer'])
         self.assertEqual({
-            'answer': 42
+            None: {
+                'answer': 42,
+            },
         }, self.test_cache.remove('/content/answer.txt'))
         self.assertEqual(None, self.test_cache.get('/content/answer.txt'))
 

--- a/grow/cache/file_cache_test.py
+++ b/grow/cache/file_cache_test.py
@@ -1,0 +1,50 @@
+"""Tests for the file cache."""
+
+import unittest
+from . import file_cache
+
+
+class FileCacheTestCase(unittest.TestCase):
+    """Tests for the file cache."""
+
+    def setUp(self):
+        self.test_cache = file_cache.FileCache()
+
+    def test_add(self):
+        """Test that adding to the file cache works."""
+        self.test_cache.add('/content/answer.txt', {
+            'answer': 42
+        })
+        self.assertEqual(42, self.test_cache.get('/content/answer.txt')['answer'])
+
+    def test_export(self):
+        """Test that exporting the file cache works."""
+        self.test_cache.add('/content/answer.txt', {
+            'answer': 42
+        })
+        self.test_cache.add('/content/question.txt', {
+            'question': '???'
+        })
+        self.assertDictEqual({
+            '/content/question.txt': {
+                'question': '???'
+            },
+            '/content/answer.txt': {
+                'answer': 42
+            },
+        }, self.test_cache.export())
+
+    def test_remove(self):
+        """Test that paths can be removed from the cache."""
+        self.test_cache.add('/content/answer.txt', {
+            'answer': 42
+        })
+        self.assertEqual(42, self.test_cache.get('/content/answer.txt')['answer'])
+        self.assertEqual({
+            'answer': 42
+        }, self.test_cache.remove('/content/answer.txt'))
+        self.assertEqual(None, self.test_cache.get('/content/answer.txt'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/grow/cache/podcache.py
+++ b/grow/cache/podcache.py
@@ -2,6 +2,7 @@
 
 from grow.cache import collection_cache
 from grow.cache import document_cache
+from grow.cache import file_cache
 from grow.cache import object_cache
 from grow.pods import dependency
 
@@ -28,6 +29,7 @@ class PodCache(object):
 
         self._collection_cache = collection_cache.CollectionCache()
         self._document_cache = document_cache.DocumentCache()
+        self._file_cache = file_cache.FileCache()
 
         self._dependency_graph = dependency.DependencyGraph()
         self._dependency_graph.add_all(yaml.get(self.KEY_DEPENDENCIES, {}))
@@ -54,6 +56,11 @@ class PodCache(object):
     def document_cache(self):
         """Cache for specific document properties."""
         return self._document_cache
+
+    @property
+    def file_cache(self):
+        """Cache for raw file contents."""
+        return self._file_cache
 
     @property
     def object_cache(self):
@@ -88,6 +95,7 @@ class PodCache(object):
         self._collection_cache.reset()
         self._dependency_graph.reset()
         self._document_cache.reset()
+        self._file_cache.reset()
 
         # Only reset the object caches if permitted.
         for meta in self._object_caches.itervalues():

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -227,13 +227,13 @@ def make_yaml_loader(pod, doc=None):
             return data
 
         @staticmethod
-        def read_csv(pod_path, locale):
+        def read_csv(pod_path):
             """Reads a csv file using a cache."""
             file_cache = pod.podcache.file_cache
-            contents = file_cache.get(pod_path, locale=locale)
+            contents = file_cache.get(pod_path)
             if contents is None:
-                contents = pod.read_csv(pod_path, locale=locale)
-                file_cache.add(pod_path, contents, locale=locale)
+                contents = pod.read_csv(pod_path)
+                file_cache.add(pod_path, contents)
             return contents
 
         @staticmethod
@@ -265,12 +265,10 @@ def make_yaml_loader(pod, doc=None):
             return func(node.value)
 
         def construct_csv(self, node):
-            locale = str(doc.locale_safe) if doc else None
-
             def func(path):
                 if doc:
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
-                return self.read_csv(path, locale=locale)
+                return self.read_csv(path)
             return self._construct_func(node, func)
 
         def construct_doc(self, node):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -594,6 +594,9 @@ class Pod(object):
 
     def on_file_changed(self, pod_path):
         """Handle when a single file has changed in the pod."""
+        # Remove any raw file in the cache.
+        self.podcache.file_cache.remove(pod_path)
+
         if pod_path == '/{}'.format(self.FILE_PODSPEC):
             self.reset_yaml()
             self.podcache.reset()

--- a/grow/templates/tags_test.py
+++ b/grow/templates/tags_test.py
@@ -14,15 +14,15 @@ class BuiltinsTestCase(unittest.TestCase):
         self.dir_path = testing.create_test_pod_dir()
         self.pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
 
-    def test_locale(self):
+    def test_locale_tag(self):
         identifier = 'de'
         expected = locales.Locale.parse(identifier)
-        self.assertEqual(expected, tags.locale(identifier))
+        self.assertEqual(expected, tags.locale_tag(identifier))
 
-    def test_locales(self):
+    def test_locales_tag(self):
         identifiers = ['de']
         expected = locales.Locale.parse_codes(identifiers)
-        self.assertEqual(expected, tags.locales(identifiers))
+        self.assertEqual(expected, tags.locales_tag(identifiers))
 
     def test_collections(self):
         collections = tags.collections(_pod=self.pod)


### PR DESCRIPTION
Improving the performance of using constructors (ex: `!g.yaml`) and template tags (ex: `g.yaml`) that rely on reading files.

Previously every time a yaml file was needed it was read fresh from the file system and reparsed:

![precache](https://user-images.githubusercontent.com/107076/30661713-14bc102c-9e02-11e7-8646-834e47aca68b.png)

After using the file caching, the number of files being read in drops dramatically:

![postcache](https://user-images.githubusercontent.com/107076/30661735-270e73aa-9e02-11e7-8b03-3f3b35cf8bf3.png)

