### PR TITLE
Fixing a bug with the caching of documents with a default locale.

### DIFF
--- a/grow/cache/collection_cache.py
+++ b/grow/cache/collection_cache.py
@@ -30,6 +30,20 @@ class CollectionCache(object):
             doc.pod_path, doc.locale_safe)
         self._cache[col.collection_path]['docs'][cache_key] = doc
 
+    def add_document_locale(self, doc, locale):
+        """Force a doc to be saved to a specific locale.
+
+        When docs have a default locale that differs from the collection default
+        it causes issues since the cache does not know that None locale is not correct.
+        This allows for the None locale to be forced to the default locale from the
+        doc.
+        """
+        col = doc.collection
+        self.ensure_collection(col)
+        cache_key = CollectionCache.generate_cache_key(
+            doc.pod_path, locale)
+        self._cache[col.collection_path]['docs'][cache_key] = doc
+
     def remove_by_path(self, path):
         """Removes the collection or document based on the path."""
         if path.startswith(collection.Collection.CONTENT_PATH):
@@ -66,6 +80,14 @@ class CollectionCache(object):
         if col.collection_path in self._cache:
             cache_key = CollectionCache.generate_cache_key(
                 doc.pod_path, doc.locale_safe)
+            if cache_key in self._cache[col.collection_path]['docs']:
+                del self._cache[col.collection_path]['docs'][cache_key]
+
+    def remove_document_locale(self, doc, locale):
+        col = doc.collection
+        if col.collection_path in self._cache:
+            cache_key = CollectionCache.generate_cache_key(
+                doc.pod_path, locale)
             if cache_key in self._cache[col.collection_path]['docs']:
                 del self._cache[col.collection_path]['docs'][cache_key]
 

--- a/grow/cache/collection_cache.py
+++ b/grow/cache/collection_cache.py
@@ -27,14 +27,8 @@ class CollectionCache(object):
         # NOTE: Using `doc.locale` causes infinite loop since it needs to load
         # the fields (which can have circular dependencies).
         cache_key = CollectionCache.generate_cache_key(
-            doc.pod_path, doc._locale_kwarg)
+            doc.pod_path, doc.locale_safe)
         self._cache[col.collection_path]['docs'][cache_key] = doc
-
-        # Recache with the real locale once we have stored it.
-        new_cache_key = CollectionCache.generate_cache_key(
-            doc.pod_path, doc.locale)
-        if cache_key != new_cache_key:
-            self._cache[col.collection_path]['docs'][new_cache_key] = doc
 
     def remove_by_path(self, path):
         """Removes the collection or document based on the path."""
@@ -71,7 +65,7 @@ class CollectionCache(object):
         col = doc.collection
         if col.collection_path in self._cache:
             cache_key = CollectionCache.generate_cache_key(
-                doc.pod_path, doc._locale_kwarg)
+                doc.pod_path, doc.locale_safe)
             if cache_key in self._cache[col.collection_path]['docs']:
                 del self._cache[col.collection_path]['docs'][cache_key]
 

--- a/grow/cache/collection_cache_test.py
+++ b/grow/cache/collection_cache_test.py
@@ -25,7 +25,7 @@ class DocumentCacheTestCase(unittest.TestCase):
         col = doc.collection
         col_cache.add_document(doc)
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
 
     def test_remove_by_path(self):
         col_cache = collection_cache.CollectionCache()
@@ -35,10 +35,10 @@ class DocumentCacheTestCase(unittest.TestCase):
 
         # Deleting a document's path removes the document.
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         col_cache.remove_by_path('/content/pages/intro.md')
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
 
         # Deleting a collection blueprint removes the entire collection.
         col_cache.add_collection(col)
@@ -60,10 +60,10 @@ class DocumentCacheTestCase(unittest.TestCase):
         # Test that documents in the collection are removed.
         col_cache.add_document(doc)
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         col_cache.remove_collection(col)
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
 
     def test_remove_document(self):
         col_cache = collection_cache.CollectionCache()
@@ -71,10 +71,10 @@ class DocumentCacheTestCase(unittest.TestCase):
         col = doc.collection
         col_cache.add_document(doc)
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         col_cache.remove_document(doc)
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
 
     def test_remove_document_locales(self):
         col_cache = collection_cache.CollectionCache()
@@ -84,14 +84,14 @@ class DocumentCacheTestCase(unittest.TestCase):
         col_cache.add_document(doc_it)
         col = doc.collection
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         self.assertEquals(doc_it, col_cache.get_document(
-            col, '/content/pages/intro.md', doc_it._locale_kwarg))
+            col, '/content/pages/intro.md', doc_it.locale_safe))
         col_cache.remove_document_locales(doc)
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc_it._locale_kwarg))
+            col, '/content/pages/intro.md', doc_it.locale_safe))
 
     def test_get_collection(self):
         col_cache = collection_cache.CollectionCache()
@@ -105,10 +105,10 @@ class DocumentCacheTestCase(unittest.TestCase):
         doc = self.pod.get_doc('/content/pages/intro.md')
         col = doc.collection
         self.assertEquals(None, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
         col_cache.add_document(doc)
         self.assertEquals(doc, col_cache.get_document(
-            col, '/content/pages/intro.md', doc._locale_kwarg))
+            col, '/content/pages/intro.md', doc.locale_safe))
 
 
 if __name__ == '__main__':

--- a/grow/pods/document_fields_test.py
+++ b/grow/pods/document_fields_test.py
@@ -492,6 +492,23 @@ class DocumentFieldsTestCase(unittest.TestCase):
             },
         }, document_fields.DocumentFields.untag(fields, locale='de_AT'))
 
+    def test_untag_with_no_base(self):
+        """Test that not having a base key does not interfere with untag and locales."""
+        fields_to_test = {
+            'foo@de': 'bar-de',
+            'baz@de': {
+                'fum@de': 'boo-de'
+            },
+        }
+        fields = copy.deepcopy(fields_to_test)
+        self.assertDictEqual({}, document_fields.DocumentFields.untag(fields))
+        self.assertDictEqual({
+            'foo': 'bar-de',
+            'baz': {
+                'fum': 'boo-de',
+            },
+        }, document_fields.DocumentFields.untag(fields, locale='de'))
+
     def test_untag_params(self):
         untag = document_fields.DocumentFields.untag
         fields_to_test = {

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -73,7 +73,8 @@ class Document(object):
         self._locale_kwarg = locale
         utils.validate_name(pod_path)
         self.pod_path = pod_path
-        self.root_pod_path = pod_path  # For multi-file localization.
+        # For multi-file localization and comparison.
+        self.root_pod_path, _ = Document.parse_localized_path(pod_path)
         self.basename = Document._clean_basename(pod_path)
         self.base, self.ext = os.path.splitext(self.basename)
         self.pod = _pod
@@ -169,8 +170,7 @@ class Document(object):
 
     def _init_locale(self, locale, pod_path):
         try:
-            self.root_pod_path, locale_from_path = \
-                Document.parse_localized_path(pod_path)
+            _, locale_from_path = Document.parse_localized_path(pod_path)
             if locale_from_path:
                 locale = locale_from_path
             return self.pod.normalize_locale(


### PR DESCRIPTION
When caching it was trying to be smart and reuse the same loaded doc if there was no `locale` kwarg provided to load the doc. This had a side effect when a document contains a different locale than the collection default.

By checking when creating the routes we can determine if the doc should have been loaded with a different locale and redo the doc loading using the document specific default locale.