### PR TITLE
Separating caches for dependency graph and object caches

### DIFF
--- a/grow/cache/podcache.py
+++ b/grow/cache/podcache.py
@@ -108,7 +108,7 @@ class PodCache(object):
 
         # Only reset the object caches if permitted.
         for meta in self._object_caches.itervalues():
-            if meta['can_reset']:
+            if meta['can_reset'] or force:
                 meta['cache'].reset()
 
     def update(self, dep_cache=None, obj_cache=None):

--- a/grow/cache/podcache.py
+++ b/grow/cache/podcache.py
@@ -21,11 +21,10 @@ class PodCacheParseError(Error):
 class PodCache(object):
     """Caching container for the pod."""
 
-    KEY_DEPENDENCIES = 'dependencies'
     KEY_GLOBAL = '__global__'
     KEY_OBJECTS = 'objects'
 
-    def __init__(self, yaml, pod):
+    def __init__(self, dep_cache, obj_cache, pod):
         self._pod = pod
 
         self._collection_cache = collection_cache.CollectionCache()
@@ -33,13 +32,13 @@ class PodCache(object):
         self._file_cache = file_cache.FileCache()
 
         self._dependency_graph = dependency.DependencyGraph()
-        self._dependency_graph.add_all(yaml.get(self.KEY_DEPENDENCIES, {}))
+        self._dependency_graph.add_all(dep_cache)
 
         self._object_caches = {}
         self.create_object_cache(
             self.KEY_GLOBAL, write_to_file=False, can_reset=True)
 
-        existing_object_caches = yaml.get(self.KEY_OBJECTS, {})
+        existing_object_caches = obj_cache
         for key, item in existing_object_caches.iteritems():
             self.create_object_cache(key, **item)
 
@@ -110,29 +109,30 @@ class PodCache(object):
 
         # Only reset the object caches if permitted.
         for meta in self._object_caches.itervalues():
-            if meta['can_reset'] or force:
+            if meta['can_reset']:
                 meta['cache'].reset()
 
     def write(self):
         """Persist the cache information to a yaml file."""
         with self._pod.profile.timer('podcache.write'):
+            if self._dependency_graph.is_dirty:
+                output = self._dependency_graph.export()
+                self._dependency_graph.mark_clean()
+                self._pod.write_file(
+                    '/{}'.format(self._pod.FILE_DEP_CACHE),
+                    json.dumps(output, sort_keys=True, indent=2, separators=(',', ': ')))
+
+            # Write out any of the object caches configured for write_to_file.
             output = {}
-            output[self.KEY_DEPENDENCIES] = self._dependency_graph.export()
-            output[self.KEY_OBJECTS] = {}
-
-            self._dependency_graph.mark_clean()
-
-            # Write out any of the object caches that request to be exported to
-            # file.
             for key, meta in self._object_caches.iteritems():
                 if meta['write_to_file']:
-                    output[self.KEY_OBJECTS][key] = {
+                    output[key] = {
                         'can_reset': meta['can_reset'],
                         'write_to_file': meta['write_to_file'],
                         'values': meta['cache'].export(),
                     }
                     meta['cache'].mark_clean()
-
-            self._pod.write_file(
-                '/{}'.format(self._pod.FILE_PODCACHE),
-                json.dumps(output, sort_keys=True, indent=2, separators=(',', ': ')))
+            if output:
+                self._pod.write_file(
+                    '/{}'.format(self._pod.FILE_OBJECT_CACHE),
+                    json.dumps(output, sort_keys=True, indent=2, separators=(',', ': ')))

--- a/grow/cache/podcache.py
+++ b/grow/cache/podcache.py
@@ -22,7 +22,6 @@ class PodCache(object):
     """Caching container for the pod."""
 
     KEY_GLOBAL = '__global__'
-    KEY_OBJECTS = 'objects'
 
     def __init__(self, dep_cache, obj_cache, pod):
         self._pod = pod
@@ -111,6 +110,19 @@ class PodCache(object):
         for meta in self._object_caches.itervalues():
             if meta['can_reset']:
                 meta['cache'].reset()
+
+    def update(self, dep_cache=None, obj_cache=None):
+        if dep_cache:
+            self._dependency_graph.add_all(dep_cache)
+
+        if obj_cache:
+            for key, meta in obj_cache.iteritems():
+                if not key in self._object_caches:
+                    self.create_object_cache(key, **meta)
+                else:
+                    self._object_caches[key]['cache'].add_all(meta['values'])
+                    self._object_caches[key]['write_to_file'] = meta['write_to_file']
+                    self._object_caches[key]['can_reset'] = meta['can_reset']
 
     def write(self):
         """Persist the cache information to a yaml file."""

--- a/grow/cache/podcache_test.py
+++ b/grow/cache/podcache_test.py
@@ -8,7 +8,7 @@ class PodCacheTestCase(unittest.TestCase):
     """Tests the PodCache object."""
 
     def setUp(self):
-        self.cache = podcache.PodCache({}, None)
+        self.cache = podcache.PodCache({}, {}, None)
 
     def test_global_object_cache(self):
         """Using a global object cache."""
@@ -25,22 +25,21 @@ class PodCacheTestCase(unittest.TestCase):
 
     def test_init(self):
         """Ability to initialize with an existing yaml file."""
-        yaml = {
-            'dependencies': {
-                '/content/test': [
-                    '/content/test1',
-                    '/content/test2',
-                ]
-            },
-            'objects': {
-                'named': {
-                    'values': {
-                        'answer': 42,
-                    }
+        dep_cache = {
+            '/content/test': [
+                '/content/test1',
+                '/content/test2',
+            ]
+        }
+        obj_cache = {
+            'named': {
+                'values': {
+                    'answer': 42,
                 }
             }
         }
-        cache = podcache.PodCache(yaml, None)
+        cache = podcache.PodCache(
+            dep_cache=dep_cache, obj_cache=obj_cache, pod=None)
 
         self.assertEqual(
             {

--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -33,11 +33,11 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
     out_dir = out_dir or os.path.join(root, 'build')
 
     pod = pods.Pod(root, storage=storage.FileStorage)
+    # Always clear the cache when building, only force if the flag is used.
+    pod.podcache.reset(force=clear_cache)
     if deployment:
         deployment_obj = pod.get_deployment(deployment)
         pod.set_env(deployment_obj.config.env)
-    if clear_cache:
-        pod.podcache.reset(force=True)
     if preprocess:
         with pod.profile.timer('grow_preprocess'):
             pod.preprocess()

--- a/grow/commands/subcommands/deploy.py
+++ b/grow/commands/subcommands/deploy.py
@@ -39,6 +39,8 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
     try:
         pod = pods.Pod(root, storage=storage.FileStorage)
         with pod.profile.timer('grow_deploy'):
+            # Always clear the cache when building.
+            pod.podcache.reset()
             deployment = pod.get_deployment(deployment_name)
             # use the deployment's environment for preprocessing and later
             # steps.

--- a/grow/commands/subcommands/stage.py
+++ b/grow/commands/subcommands/stage.py
@@ -38,6 +38,8 @@ def stage(context, pod_path, remote, preprocess, subdomain, api_key, force_untra
             # use the deployment's environment for preprocessing and later
             # steps.
             pod.set_env(deployment.config.env)
+            # Always clear the cache when building.
+            pod.podcache.reset()
             require_translations = pod.podspec.localization.get(
                 'require_translations', False)
             require_translations = require_translations and not force_untranslated


### PR DESCRIPTION
Adds better cache clearing for `build`, `stage`, `deploy` subcommands as well.