### PR TITLE
Add RLock around get_jinja_env

### DIFF
--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import threading
 import time
 import progressbar
 import yaml
@@ -75,6 +76,7 @@ class Pod(object):
         self._disabled = set(
             self.FEATURE_TRANSLATION_STATS,
         )
+        self._jinja_env_lock = threading.RLock()
 
         # Ensure preprocessors are loaded when pod is initialized.
         # Preprocessors may modify the environment in ways that are required by
@@ -435,31 +437,32 @@ class Pod(object):
 
     @utils.memoize
     def get_jinja_env(self, locale='', root=None):
-        kwargs = {
-            'autoescape': True,
-            'extensions': [
-                'jinja2.ext.autoescape',
-                'jinja2.ext.do',
-                'jinja2.ext.i18n',
-                'jinja2.ext.loopcontrols',
-                'jinja2.ext.with_',
-            ],
-            'loader': self.storage.JinjaLoader(self.root if root is None else root),
-            'lstrip_blocks': True,
-            'trim_blocks': True,
-        }
-        if self.env.cached:
-            kwargs['bytecode_cache'] = self._get_bytecode_cache()
-        kwargs['extensions'].extend(self.list_jinja_extensions())
-        env = jinja_dependency.DepEnvironment(**kwargs)
-        env.filters.update(filters.create_builtin_filters())
-        get_gettext_func = self.catalogs.get_gettext_translations
-        # pylint: disable=no-member
-        env.install_gettext_callables(
-            lambda x: get_gettext_func(locale).ugettext(x),
-            lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
-            newstyle=True)
-        return env
+        with self._jinja_env_lock:
+            kwargs = {
+                'autoescape': True,
+                'extensions': [
+                    'jinja2.ext.autoescape',
+                    'jinja2.ext.do',
+                    'jinja2.ext.i18n',
+                    'jinja2.ext.loopcontrols',
+                    'jinja2.ext.with_',
+                ],
+                'loader': self.storage.JinjaLoader(self.root if root is None else root),
+                'lstrip_blocks': True,
+                'trim_blocks': True,
+            }
+            if self.env.cached:
+                kwargs['bytecode_cache'] = self._get_bytecode_cache()
+            kwargs['extensions'].extend(self.list_jinja_extensions())
+            env = jinja_dependency.DepEnvironment(**kwargs)
+            env.filters.update(filters.create_builtin_filters())
+            get_gettext_func = self.catalogs.get_gettext_translations
+            # pylint: disable=no-member
+            env.install_gettext_callables(
+                lambda x: get_gettext_func(locale).ugettext(x),
+                lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
+                newstyle=True)
+            return env
 
     def get_routes(self):
         return self.routes


### PR DESCRIPTION
This seems to fix #577 in my local dev testing, but I dunno what it does to performance. I'm guessing the memoize decorator will make the lock useless after the first invocation anyway, but please take a look and let me know if you think there's a better way to handle this.