### PR TITLE
Initial replacement of the `(path, content)` with `RenderedDocument`.

### DIFF
--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -80,7 +80,7 @@ class AmazonS3Destination(base.BaseDestination):
 
     def write_file(self, rendered_doc, policy='public-read'):
         path = rendered_doc.path
-        content = rendered_doc.content
+        content = rendered_doc.read()
         path = path.lstrip('/')
         path = path if path != '' else self.config.index_document
         if isinstance(content, unicode):

--- a/grow/deployments/destinations/amazon_s3.py
+++ b/grow/deployments/destinations/amazon_s3.py
@@ -9,6 +9,7 @@ import cStringIO
 import logging
 import os
 import mimetypes
+from grow.pods import rendered_document
 
 
 class Config(messages.Message):
@@ -59,7 +60,8 @@ class AmazonS3Destination(base.BaseDestination):
 
     def write_control_file(self, path, content):
         path = os.path.join(self.control_dir, path.lstrip('/'))
-        return self.write_file(path, content, policy='private')
+        return self.write_file(
+            rendered_document.RenderedDocument(path, content), policy='private')
 
     def read_file(self, path):
         file_key = key.Key(self.bucket)
@@ -76,7 +78,9 @@ class AmazonS3Destination(base.BaseDestination):
         bucket_key.key = path.lstrip('/')
         self.bucket.delete_key(bucket_key)
 
-    def write_file(self, path, content, policy='public-read'):
+    def write_file(self, rendered_doc, policy='public-read'):
+        path = rendered_doc.path
+        content = rendered_doc.content
         path = path.lstrip('/')
         path = path if path != '' else self.config.index_document
         if isinstance(content, unicode):

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -39,11 +39,11 @@ destination, you'll just have to implement the following methods/properties:
   read_file(self, path)
     Reads a file at the destination, returning the file's content.
 
-  write_file(self, path, content)
-    Writes a file at the destination, given the file's pod path and its content.
+  write_file(self, rendered_doc)
+    Writes a file at the destination, given the file's rendered_document.
 
-  write_files(self, paths_to_contents)
-    Writes files in bulk, given a mapping of paths to file contents.
+  write_files(self, paths_to_rendered_doc)
+    Writes files in bulk, given a mapping of paths to rendered_document.
 
   KIND
     A string identifying the deployment.
@@ -83,6 +83,7 @@ from grow.deployments import tests
 from grow.performance import profile_report
 from grow.pods import env
 from grow.pods import pods
+from grow.pods import rendered_document
 from . import messages
 
 
@@ -191,11 +192,11 @@ class BaseDestination(object):
         """Returns a file-like object."""
         raise NotImplementedError
 
-    def write_files(self, paths_to_contents):
+    def write_files(self, paths_to_rendered_doc):
         """Writes files in bulk."""
         raise NotImplementedError
 
-    def write_file(self, path, content):
+    def write_file(self, rendered_doc):
         """Writes an individual file."""
         raise NotImplementedError
 
@@ -226,12 +227,17 @@ class BaseDestination(object):
     def write_control_file(self, path, content):
         path = os.path.join(self.control_dir, path.lstrip('/'))
         if self.config.keep_control_dir:
-            return self.pod.write_file(path, content)
+            return self.pod.write_file(
+                rendered_document.RenderedDocument(path, content))
         if self._has_custom_control_dir:
-            return self.storage.write(path, content)
+            return self.storage.write(
+                rendered_document.RenderedDocument(path, content))
         if self.batch_writes:
-            return self.write_files({path: content})
-        return self.write_file(path, content)
+            return self.write_files({
+                path: rendered_document.RenderedDocument(path, content)
+            })
+        return self.write_file(
+            rendered_document.RenderedDocument(path, content))
 
     def test(self):
         results = messages.TestResultsMessage(test_results=[])
@@ -268,7 +274,7 @@ class BaseDestination(object):
             deployed_index = self._get_remote_index()
             if require_translations:
                 self.pod.enable(self.pod.FEATURE_TRANSLATION_STATS)
-            diff, new_index, paths_to_content = indexes.Diff.stream(
+            diff, new_index, paths_to_rendered_doc = indexes.Diff.stream(
                 deployed_index, content_generator, repo=repo, is_partial=is_partial)
             self._diff = diff
             if indexes.Diff.is_empty(diff):
@@ -287,7 +293,7 @@ class BaseDestination(object):
                     logging.info('Aborted.')
                     return
             indexes.Diff.apply(
-                diff, paths_to_content, write_func=self.write_file,
+                diff, paths_to_rendered_doc, write_func=self.write_file,
                 batch_write_func=self.write_files, delete_func=self.delete_file,
                 threaded=self.threaded, batch_writes=self.batch_writes)
             self.write_control_file(

--- a/grow/deployments/destinations/git_destination.py
+++ b/grow/deployments/destinations/git_destination.py
@@ -136,9 +136,9 @@ class GitDestination(base.BaseDestination):
             self.adds.remove(out_path)
         return out_path
 
-    def write_file(self, path, content):
-        if isinstance(content, unicode):
-            content = content.encode('utf-8')
+    def write_file(self, rendered_doc):
+        path = rendered_doc.path
+        content = rendered_doc.content
         out_path = os.path.join(self.repo_path, self.config.root_dir.lstrip('/'),
                                 path.lstrip('/'))
         self.storage.write(out_path, content)

--- a/grow/deployments/destinations/git_destination.py
+++ b/grow/deployments/destinations/git_destination.py
@@ -138,7 +138,7 @@ class GitDestination(base.BaseDestination):
 
     def write_file(self, rendered_doc):
         path = rendered_doc.path
-        content = rendered_doc.content
+        content = rendered_doc.read()
         out_path = os.path.join(self.repo_path, self.config.root_dir.lstrip('/'),
                                 path.lstrip('/'))
         self.storage.write(out_path, content)

--- a/grow/deployments/destinations/git_destination_test.py
+++ b/grow/deployments/destinations/git_destination_test.py
@@ -29,8 +29,8 @@ class GitDestinationTestCase(unittest.TestCase):
         pod.write_file('/views/base.html', str(random.randint(0, 999)))
         deployment = pod.get_deployment('git')
         paths = []
-        for path, _ in deployment.dump(pod):
-            paths.append(path)
+        for rendered_doc in deployment.dump(pod):
+            paths.append(rendered_doc.path)
         repo = utils.get_git_repo(pod.root)
         stats_obj = stats.Stats(pod, paths=paths)
         deployment.deploy(deployment.dump(pod), stats=stats_obj, repo=repo,

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -7,6 +7,7 @@ from gcs_oauth2_boto_plugin import oauth2_helper
 from grow.common import oauth
 from grow.common import utils
 from grow.pods import env
+from grow.pods import rendered_document
 from protorpc import messages
 import boto
 import cStringIO
@@ -86,7 +87,8 @@ class GoogleCloudStorageDestination(base.BaseDestination):
 
     def write_control_file(self, path, content):
         path = os.path.join(self.control_dir, path.lstrip('/'))
-        return self.write_file(path, content, policy='private')
+        return self.write_file(
+            rendered_document.RenderedDocument(path, content), policy='private')
 
     def read_file(self, path):
         file_key = key.Key(self.bucket)
@@ -103,9 +105,9 @@ class GoogleCloudStorageDestination(base.BaseDestination):
         file_key.key = path.lstrip('/')
         self.bucket.delete_key(file_key)
 
-    def write_file(self, path, content, policy='public-read'):
-        if isinstance(content, unicode):
-            content = content.encode('utf-8')
+    def write_file(self, rendered_doc, policy='public-read'):
+        path = rendered_doc.path
+        content = rendered_doc.content
         path = path.lstrip('/')
         path = path if path != '' else self.config.main_page_suffix
         fp = cStringIO.StringIO()

--- a/grow/deployments/destinations/google_cloud_storage.py
+++ b/grow/deployments/destinations/google_cloud_storage.py
@@ -107,7 +107,7 @@ class GoogleCloudStorageDestination(base.BaseDestination):
 
     def write_file(self, rendered_doc, policy='public-read'):
         path = rendered_doc.path
-        content = rendered_doc.content
+        content = rendered_doc.read()
         path = path.lstrip('/')
         path = path if path != '' else self.config.main_page_suffix
         fp = cStringIO.StringIO()

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -34,9 +34,9 @@ class LocalDestination(base.BaseDestination):
         out_path = os.path.join(self.out_dir, path.lstrip('/'))
         self.storage.delete(out_path)
 
-    def write_file(self, path, content):
-        if isinstance(content, unicode):
-            content = content.encode('utf-8')
+    def write_file(self, rendered_doc):
+        path = rendered_doc.path
+        content = rendered_doc.content
         out_path = os.path.join(self.out_dir, path.lstrip('/'))
         fp = self.storage.write(out_path, content)
         fp.close()

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -36,7 +36,7 @@ class LocalDestination(base.BaseDestination):
 
     def write_file(self, rendered_doc):
         path = rendered_doc.path
-        content = rendered_doc.content
+        content = rendered_doc.read()
         out_path = os.path.join(self.out_dir, path.lstrip('/'))
         fp = self.storage.write(out_path, content)
         fp.close()

--- a/grow/deployments/destinations/scp.py
+++ b/grow/deployments/destinations/scp.py
@@ -62,7 +62,7 @@ class ScpDestination(base.BaseDestination):
 
     def write_file(self, rendered_doc):
         path = rendered_doc.path
-        content = rendered_doc.content
+        content = rendered_doc.read()
         path = os.path.join(self.root_dir, path.lstrip('/'))
         self._mkdirs(os.path.dirname(path))
         fp = self.sftp.open(path, 'w')

--- a/grow/deployments/destinations/scp.py
+++ b/grow/deployments/destinations/scp.py
@@ -60,9 +60,9 @@ class ScpDestination(base.BaseDestination):
         path = os.path.join(self.root_dir, path.lstrip('/'))
         self.sftp.remove(path)
 
-    def write_file(self, path, content):
-        if isinstance(content, unicode):
-            content = content.encode('utf-8')
+    def write_file(self, rendered_doc):
+        path = rendered_doc.path
+        content = rendered_doc.content
         path = os.path.join(self.root_dir, path.lstrip('/'))
         self._mkdirs(os.path.dirname(path))
         fp = self.sftp.open(path, 'w')

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -104,7 +104,6 @@ class WebReviewDestination(base.BaseDestination):
                     ' Commit first then deploy to WebReview.')
         result = super(WebReviewDestination, self).deploy(*args, **kwargs)
         if self.success:
-            logging.info('DEBUG: Deployment successful, finalizing webreview.')
             finalize_response = self.webreview.finalize()
             if 'fileset' in finalize_response:
                 url = finalize_response['fileset']['url']

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -140,24 +140,21 @@ class WebReviewDestination(base.BaseDestination):
         except webreview.RpcError as e:
             raise base.Error(e.message)
 
-    def write_files(self, paths_to_contents):
+    def write_files(self, paths_to_rendered_doc):
         try:
-            for path, content in paths_to_contents.iteritems():
-                if isinstance(content, unicode):
-                    paths_to_contents[path] = content.encode('utf-8')
-            paths_to_contents, errors = self.webreview.write(paths_to_contents)
+            paths_to_rendered_doc, errors = self.webreview.write(paths_to_rendered_doc)
             if errors:
                 raise base.Error(errors)
-            return paths_to_contents
+            return paths_to_rendered_doc
         except webreview.RpcError as e:
             raise base.Error(e.message)
 
     def delete_file(self, paths):
         try:
-            paths_to_contents, errors = self.webreview.delete(paths)
+            paths, errors = self.webreview.delete(paths)
             if errors:
                 raise base.Error(errors)
-            return paths_to_contents
+            return paths
         except webreview.RpcError as e:
             raise base.Error(e.message)
 

--- a/grow/deployments/indexes_test.py
+++ b/grow/deployments/indexes_test.py
@@ -2,6 +2,7 @@ from . import indexes
 from . import messages
 from grow.common import utils
 from grow.pods import pods
+from grow.pods import rendered_document
 from grow.pods import storage
 from grow.testing import testing
 import unittest
@@ -19,14 +20,14 @@ class IndexTest(unittest.TestCase):
 
     def test_diff(self):
         my_index = indexes.Index.create({
-          '/file.txt': 'test',
-          '/file2.txt': 'test',
-          '/foo/file.txt': 'test',
+            '/file.txt': rendered_document.RenderedDocument('/file.txt', 'test'),
+            '/file2.txt': rendered_document.RenderedDocument('/file2.txt', 'test'),
+            '/foo/file.txt': rendered_document.RenderedDocument('/foo/file.txt', 'test'),
         })
         their_index = indexes.Index.create({
-          '/file2.txt': 'change',
-          '/foo/file.txt': 'test',
-          '/bar/new.txt': 'test',
+            '/file2.txt': rendered_document.RenderedDocument('/file2.txt', 'change'),
+            '/foo/file.txt': rendered_document.RenderedDocument('/foo/file.txt', 'test'),
+            '/bar/new.txt': rendered_document.RenderedDocument('/bar/new.txt', 'test'),
         })
         expected = messages.DiffMessage(
             adds=[messages.FileMessage(path='/file.txt')],

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -130,8 +130,8 @@ class PodTest(unittest.TestCase):
             '/yaml_test/index.html',
         ]
         result = {}
-        for path, rendered in self.pod.dump():
-            result[path] = rendered
+        for rendered_doc in self.pod.dump():
+            result[rendered_doc.path] = None
         self.assertItemsEqual(paths, result)
 
     def test_to_message(self):
@@ -231,8 +231,8 @@ class PodTest(unittest.TestCase):
             '/static/extensionless',
         ]
         paths = []
-        for path, _ in pod.dump():
-            paths.append(path)
+        for rendered_doc in pod.dump():
+            paths.append(rendered_doc.path)
         self.assertItemsEqual(expected, paths)
 
         # Verify export does not append suffix.
@@ -242,8 +242,8 @@ class PodTest(unittest.TestCase):
             '/static/extensionless',
         ]
         paths = []
-        for path, _ in pod.export():
-            paths.append(path)
+        for rendered_doc in pod.export():
+            paths.append(rendered_doc.path)
         self.assertItemsEqual(expected, paths)
 
 

--- a/grow/pods/rendered_document.py
+++ b/grow/pods/rendered_document.py
@@ -36,8 +36,8 @@ class RenderedDocument(object):
 
         self.hash = hashlib.sha1(content).hexdigest()
 
-        if tmp_dir:
-            with open(self.filename, "w") as tmp_file:
+        if self.tmp_dir:
+            with open(self._get_tmp_filename(), "w") as tmp_file:
                 tmp_file.write(content)
         else:
             self._content = content

--- a/grow/pods/rendered_document.py
+++ b/grow/pods/rendered_document.py
@@ -1,0 +1,14 @@
+"""Tracks the rendered document information."""
+
+import hashlib
+
+class RenderedDocument(object):
+    """Keeps track of the information for the rendered document."""
+
+    def __init__(self, path, content):
+        if isinstance(content, unicode):
+            content = content.encode('utf-8')
+
+        self.path = path
+        self.content = content
+        self.hash = hashlib.sha1(content).hexdigest()

--- a/grow/pods/rendered_document.py
+++ b/grow/pods/rendered_document.py
@@ -19,13 +19,13 @@ class RenderedDocument(object):
             with open(self.filename, "w") as tmp_file:
                 tmp_file.write(content)
         else:
-            self.content = content
+            self._content = content
 
     @property
     def content(self):
         """Reads the content when it needs it."""
         if not self.tmp_dir:
-            return self.content
+            return self._content
 
         with open(self.filename, "r") as tmp_file:
             file_contents = tmp_file.read()

--- a/grow/pods/rendered_document.py
+++ b/grow/pods/rendered_document.py
@@ -1,14 +1,39 @@
 """Tracks the rendered document information."""
 
 import hashlib
+import os
+
 
 class RenderedDocument(object):
     """Keeps track of the information for the rendered document."""
 
-    def __init__(self, path, content):
+    def __init__(self, path, content, tmp_dir=None):
         if isinstance(content, unicode):
             content = content.encode('utf-8')
 
         self.path = path
-        self.content = content
         self.hash = hashlib.sha1(content).hexdigest()
+        self.tmp_dir = tmp_dir
+
+        if tmp_dir:
+            with open(self.filename, "w") as tmp_file:
+                tmp_file.write(content)
+        else:
+            self.content = content
+
+    @property
+    def content(self):
+        """Reads the content when it needs it."""
+        if not self.tmp_dir:
+            return self.content
+
+        with open(self.filename, "r") as tmp_file:
+            file_contents = tmp_file.read()
+            if isinstance(file_contents, unicode):
+                file_contents = file_contents.encode('utf-8')
+            return file_contents
+
+    @property
+    def filename(self):
+        """Temp filename if has temporary dir."""
+        return os.path.join(self.tmp_dir, self.hash)

--- a/grow/pods/rendered_document.py
+++ b/grow/pods/rendered_document.py
@@ -7,33 +7,37 @@ import os
 class RenderedDocument(object):
     """Keeps track of the information for the rendered document."""
 
-    def __init__(self, path, content, tmp_dir=None):
+    def __init__(self, path, content=None, tmp_dir=None):
+        self.path = path
+        self.tmp_dir = tmp_dir
+        self.hash = None
+
+        if content:
+            self.write(content)
+
+    def _get_tmp_filename(self):
+        """Temp filename if has temporary dir."""
+        return os.path.join(self.tmp_dir, self.hash)
+
+    def read(self):
+        """Reads the content when it needs it."""
+        if not self.tmp_dir:
+            return self._content
+
+        with open(self._get_tmp_filename(), "r") as tmp_file:
+            file_contents = tmp_file.read()
+            if isinstance(file_contents, unicode):
+                file_contents = file_contents.encode('utf-8')
+            return file_contents
+
+    def write(self, content):
         if isinstance(content, unicode):
             content = content.encode('utf-8')
 
-        self.path = path
         self.hash = hashlib.sha1(content).hexdigest()
-        self.tmp_dir = tmp_dir
 
         if tmp_dir:
             with open(self.filename, "w") as tmp_file:
                 tmp_file.write(content)
         else:
             self._content = content
-
-    @property
-    def content(self):
-        """Reads the content when it needs it."""
-        if not self.tmp_dir:
-            return self._content
-
-        with open(self.filename, "r") as tmp_file:
-            file_contents = tmp_file.read()
-            if isinstance(file_contents, unicode):
-                file_contents = file_contents.encode('utf-8')
-            return file_contents
-
-    @property
-    def filename(self):
-        """Temp filename if has temporary dir."""
-        return os.path.join(self.tmp_dir, self.hash)

--- a/grow/pods/sitemap_test.py
+++ b/grow/pods/sitemap_test.py
@@ -82,8 +82,8 @@ class SitemapTest(unittest.TestCase):
         })
         pod.write_file('/views/base.html', '{{doc.html}}')
         paths_to_contents = {}
-        for path, content in pod.export():
-            paths_to_contents[path] = content
+        for rendered_doc in pod.export():
+            paths_to_contents[rendered_doc.path] = rendered_doc.content
         content = paths_to_contents['/sitemap.xml']
         self.assertEqual(content, 'foo')
 

--- a/grow/pods/sitemap_test.py
+++ b/grow/pods/sitemap_test.py
@@ -83,7 +83,7 @@ class SitemapTest(unittest.TestCase):
         pod.write_file('/views/base.html', '{{doc.html}}')
         paths_to_contents = {}
         for rendered_doc in pod.export():
-            paths_to_contents[rendered_doc.path] = rendered_doc.content
+            paths_to_contents[rendered_doc.path] = rendered_doc.read()
         content = paths_to_contents['/sitemap.xml']
         self.assertEqual(content, 'foo')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,5 +39,5 @@ six==1.10.0
 texttable-fixed==0.8.3
 translitcodec==0.4.0
 watchdog==0.8.3
-webreview==0.0.68
+webreview==0.0.69
 xtermcolor==1.3


### PR DESCRIPTION
Instead of returning a path and a content, this changes it to return a `RenderedDocument` object. This object will write the contents to a temp file then store the reference. Then when the content is needed at upload it can read the content back in from the temp file.

This will hopefully reduce the about of memory needed as the objects about the content are quite small.