### PR TITLE
Auto update and default true for install prompts

### DIFF
--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -9,11 +9,13 @@ import sys
 import urlparse
 import requests
 import semantic_version
+import yaml
 from grow.common import config
 from grow.common import utils
 from xtermcolor import colorize
 
 
+RC_FILE_NAME = '.growrc.yaml'
 VERSION = config.VERSION
 RELEASES_API = 'https://api.github.com/repos/grow/grow/releases'
 INSTALLER_COMMAND = ('/usr/bin/python -c "$(curl -fsSL '
@@ -32,6 +34,23 @@ class Error(Exception):
 
 class LatestVersionCheckError(Error):
     pass
+
+
+def get_rc_config():
+    """Reads the RC config from the system."""
+    rc_file = os.path.expanduser('~/{}'.format(RC_FILE_NAME))
+    if not os.path.isfile(rc_file):
+        return {}
+    with open(rc_file, 'r') as conf:
+        contents = yaml.load(conf.read())
+    return contents
+
+
+def write_rc_config(rc_config):
+    """Writes the RC config to the system."""
+    rc_file = os.path.expanduser('~/{}'.format(RC_FILE_NAME))
+    with open(rc_file, 'w') as conf:
+        conf.write(yaml.safe_dump(rc_config))
 
 
 def get_this_version():
@@ -88,9 +107,23 @@ def check_for_sdk_updates(auto_update_prompt=False):
     logging.info('  See release notes: {}'.format(url))
     logging.info('  Your version: {}, latest version: {}'.format(
         colorize(yours, ansi=226), colorize(theirs, ansi=82)))
+
     if utils.is_packaged_app() and auto_update_prompt:
-        if raw_input('Auto update now? [y/N]: ').lower() != 'y':
-            return
+        rc_config = get_rc_config()
+        use_auto_update = rc_config.get('always_update', False)
+
+        if use_auto_update:
+            logging.info('  > Auto-updating to version: {}'.format(
+                colorize(theirs, ansi=82)))
+        else:
+            choice = raw_input(
+                'Auto update now? [Y]es [n]o [a]lways: ').strip().lower()
+            if choice not in ('y', 'a', ''):
+                return
+            if choice == 'a':
+                rc_config['always_update'] = True
+                write_rc_config(rc_config)
+
         if subprocess.call(INSTALLER_COMMAND, shell=True) == 0:
             logging.info('Restarting...')
             os.execl(sys.argv[0], *sys.argv)  # Restart on successful install.

--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -110,7 +110,7 @@ def check_for_sdk_updates(auto_update_prompt=False):
 
     if utils.is_packaged_app() and auto_update_prompt:
         rc_config = get_rc_config()
-        use_auto_update = rc_config.get('always_update', False)
+        use_auto_update = rc_config.get('update', {}).get('always', False)
 
         if use_auto_update:
             logging.info('  > Auto-updating to version: {}'.format(
@@ -121,7 +121,9 @@ def check_for_sdk_updates(auto_update_prompt=False):
             if choice not in ('y', 'a', ''):
                 return
             if choice == 'a':
-                rc_config['always_update'] = True
+                rc_config['update'] = {
+                    'always': True,
+                }
                 write_rc_config(rc_config)
 
         if subprocess.call(INSTALLER_COMMAND, shell=True) == 0:
@@ -297,7 +299,8 @@ def install_extensions(pod):
         text = '[✓] Installed: extensions.txt -> {}'
         pod.logger.info(text.format(extensions_dir))
         return True
-    pod.logger.error('[✘] There was an error running "{}".'.format(pip_command))
+    pod.logger.error(
+        '[✘] There was an error running "{}".'.format(pip_command))
 
 
 def install_yarn(pod):

--- a/grow/common/sdk_utils.py
+++ b/grow/common/sdk_utils.py
@@ -117,7 +117,7 @@ def check_for_sdk_updates(auto_update_prompt=False):
                 colorize(theirs, ansi=82)))
         else:
             choice = raw_input(
-                'Auto update now? [Y]es [n]o [a]lways: ').strip().lower()
+                'Auto update now? [Y]es / [n]o / [a]lways: ').strip().lower()
             if choice not in ('y', 'a', ''):
                 return
             if choice == 'a':

--- a/install.py
+++ b/install.py
@@ -47,9 +47,13 @@ def hai(text, *args):
     })
 
 
-def orly(text):
-    resp = raw_input(text)
-    return resp.lower() == 'y'
+def orly(text, default=False):
+    resp = raw_input(text).strip().lower()
+    if resp == 'y':
+        return True
+    elif resp == 'n':
+        return False
+    return default
 
 
 def find_conflicting_aliases(existing_aliases, bin_path):
@@ -151,7 +155,7 @@ def install(rc_path=None, bin_path=None, force=False):
         hai('{blue}==>{/blue} {green}An alias for "grow" will be created in:{/green} {}', rc_path)
 
     if not force:
-        result = orly('Continue? [y/N]: ')
+        result = orly('Continue installation? [Y]es / [n]o: ', default=True)
         if not result:
             hai('Aborted installation.')
             sys.exit(-1)


### PR DESCRIPTION
Switching the auto-updater to allow for an `always` option that stores the config in a `~/.growrc.yaml` file. If the user selects always then the latest version will automatically be installed.

Also updated the installer to default to `True` when a user just presses enter without typing.

Part of #582