### PR TITLE
Better Error for Wrong Front Matter Type

### DIFF
--- a/grow/pods/document_front_matter.py
+++ b/grow/pods/document_front_matter.py
@@ -82,8 +82,8 @@ class DocumentFrontMatter(object):
             new_data = self._load_yaml(self._raw_front_matter)
             if not isinstance(new_data, dict):
                 raise BadFormatError(
-                    'Front matter needs to be a dictionary, found {}'.format(
-                        type(new_data)))
+                    'Front matter needs to be a dictionary, found <{}>'.format(
+                        type(new_data).__name__))
             _update_deep(self.data, new_data)
 
     def _load_yaml(self, raw_yaml):

--- a/grow/pods/document_front_matter.py
+++ b/grow/pods/document_front_matter.py
@@ -79,7 +79,12 @@ class DocumentFrontMatter(object):
                 self._doc.raw_content)
 
         if self._raw_front_matter:
-            _update_deep(self.data, self._load_yaml(self._raw_front_matter))
+            new_data = self._load_yaml(self._raw_front_matter)
+            if not isinstance(new_data, dict):
+                raise BadFormatError(
+                    'Front matter needs to be a dictionary, found {}'.format(
+                        type(new_data)))
+            _update_deep(self.data, new_data)
 
     def _load_yaml(self, raw_yaml):
         try:

--- a/grow/pods/document_front_matter.py
+++ b/grow/pods/document_front_matter.py
@@ -82,8 +82,8 @@ class DocumentFrontMatter(object):
             new_data = self._load_yaml(self._raw_front_matter)
             if not isinstance(new_data, dict):
                 raise BadFormatError(
-                    'Front matter needs to be a dictionary, found <{}>'.format(
-                        type(new_data).__name__))
+                    'Front matter needs to be a dictionary: {} <{}>'.format(
+                        self._doc.pod_path, type(new_data).__name__))
             _update_deep(self.data, new_data)
 
     def _load_yaml(self, raw_yaml):

--- a/grow/pods/document_front_matter_test.py
+++ b/grow/pods/document_front_matter_test.py
@@ -41,8 +41,6 @@ class DocumentFrontmatterTestCase(unittest.TestCase):
             - alpha
             - beta
             - charlie
-            ---
-            foo: bar
             """).lstrip()
         with self.assertRaises(document_front_matter.BadFormatError):
             document_front_matter.DocumentFrontMatter(

--- a/grow/pods/document_front_matter_test.py
+++ b/grow/pods/document_front_matter_test.py
@@ -36,6 +36,18 @@ class DocumentFrontmatterTestCase(unittest.TestCase):
             document_front_matter.DocumentFrontMatter(
                 doc, raw_front_matter=content)
 
+        doc = self.pod.get_doc('/content/pages/html.html')
+        content = textwrap.dedent("""
+            - alpha
+            - beta
+            - charlie
+            ---
+            foo: bar
+            """).lstrip()
+        with self.assertRaises(document_front_matter.BadFormatError):
+            document_front_matter.DocumentFrontMatter(
+                doc, raw_front_matter=content)
+
     def test_empty_raw_front_matter(self):
         """Test for empty or missing front matter."""
         doc = self.pod.get_doc('/content/pages/html.html')


### PR DESCRIPTION
Improves the error shown when a document uses a non-dictionary type as the front matter for a document.

Fixes #529