### PR TITLE
Better re-route path conflict reporting.

### DIFF
--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -219,3 +219,6 @@ class RouteInfo(object):
     def __init__(self, kind, meta=None):
         self.kind = kind
         self.meta = meta or {}
+
+    def __repr__(self):
+        return '<RouteInfo kind={} meta={}>'.format(self.kind, self.meta)

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -216,6 +216,9 @@ class Router(object):
 class RouteInfo(object):
     """Organize information stored in the routes."""
 
+    def __eq__(self, other):
+        return self.kind == other.kind and self.meta == other.meta
+
     def __init__(self, kind, meta=None):
         self.kind = kind
         self.meta = meta or {}

--- a/grow/routing/routes.py
+++ b/grow/routing/routes.py
@@ -18,7 +18,7 @@ class PathConflictError(Error):
 
     def __init__(self, path, value, existing):
         super(PathConflictError, self).__init__(
-            'Path already exists: {} (New: {} : Existing: {})'.format(path, value, existing))
+            'Path already exists: {} ({} != {})'.format(path, existing, value))
         self.path = path
         self.value = value
 

--- a/grow/routing/routes.py
+++ b/grow/routing/routes.py
@@ -121,7 +121,7 @@ class RoutesDict(object):
 
     def add(self, path, value):
         """Add a new doc to the route trie."""
-        if path in self._root:
+        if path in self._root and self._root[path] != value:
             raise PathConflictError(path, value, self._root[path])
         self._root[path] = value
 
@@ -232,7 +232,7 @@ class RouteNode(object):
         """Recursively add into the trie based upon the given segments."""
 
         if not segments:
-            if self.path:
+            if self.path and self.value != value:
                 raise PathConflictError(path, value, self.value)
             self.path = path
             self.value = value
@@ -258,7 +258,8 @@ class RouteNode(object):
         # Insert as a wildcard node.
         if segment and segment[0] is PREFIX_WILDCARD:
             segment = segment[1:]  # Don't need the prefix character.
-            if PREFIX_WILDCARD in self._dynamic_children:
+            if (PREFIX_WILDCARD in self._dynamic_children
+                    and self._dynamic_children[PREFIX_WILDCARD].value != value):
                 raise PathConflictError(
                     path, value, self._dynamic_children[PREFIX_WILDCARD].value)
             new_node = RouteWildcardNode(param_name=segment or PREFIX_WILDCARD)


### PR DESCRIPTION
Currently the re-route tells you there was a conflict, but doesn't tell you what it conflicts with.