### PR TITLE
Adding Traceback log to `locate-untranslated` flag

### DIFF
--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -182,7 +182,10 @@ class BaseDestination(object):
                               pattern=re.compile(r'\.po$'))
         for _, catalog in catalogs.iteritems():
             catalog.save()
-        if catalogs:
+        if self.pod.translation_stats.stacktraces:
+            self.pod.write_file(os.path.join(dir_path, 'tracebacks.log'),
+                self.pod.translation_stats.export_untranslated_tracebacks())
+        if catalogs or self.pod.translation_stats.stacktraces:
             logging.info('Untranslated strings exported to {}'.format(dir_path))
 
     def get_env(self):

--- a/grow/templates/tags.py
+++ b/grow/templates/tags.py
@@ -165,7 +165,8 @@ def make_doc_gettext(doc):
         # used for tracking untranslated strings.
         message = catalog[__string] \
             or babel_catalog.Message(__string, locations=[(doc.pod_path, 0)])
-        translation_stats.tick(message, doc.locale, doc.default_locale)
+        translation_stats.tick(
+            message, doc.locale, doc.default_locale, location=doc.pod_path)
         return __context.call(__context.resolve('gettext'), __string, *args, **kwargs)
     return gettext
 

--- a/grow/translators/translation_stats.py
+++ b/grow/translators/translation_stats.py
@@ -1,6 +1,9 @@
 """Translation stats collection and reporting."""
 
+import datetime
+import io
 import logging
+import traceback
 import texttable
 
 
@@ -11,13 +14,16 @@ class TranslationStats(object):
     def __init__(self):
         self._locale_to_message = {}
         self._untranslated = {}
+        self._stacktraces = []
 
     @property
     def messages(self):
+        """All messages and counts."""
         return self._locale_to_message
 
     @property
     def untranslated(self):
+        """Untranslated messages by locale."""
         tracking = {}
         for locale, messages in self._untranslated.iteritems():
             if locale not in tracking:
@@ -27,7 +33,32 @@ class TranslationStats(object):
                     locale][message]
         return tracking
 
+    @property
+    def count_untranslated(self):
+        """Max number of untranslated strings for any locale."""
+        untranslated_ids = set()
+        for _, messages in self._untranslated.iteritems():
+            for message in messages:
+                untranslated_ids.add(message)
+        return len(untranslated_ids)
+
+    @property
+    def stacktraces(self):
+        return self._stacktraces
+
+    @staticmethod
+    def _simplify_traceback(tb):
+        """Remove extra layers of the traceback to just get best bits."""
+        start = 0
+        end = len(tb) - 3
+        for i, item in enumerate(tb):
+            if 'jinja' in item:
+                start = i + 1
+                break
+        return tb[start:end]
+
     def export(self):
+        """Export messages and untranslated strings."""
         return {
             'messages': self.messages,
             'untranslated': self.untranslated,
@@ -45,7 +76,50 @@ class TranslationStats(object):
                 catalog.add(message)
         return locale_to_catalog
 
+    def export_untranslated_tracebacks(self):
+        """Export the untranslated tracebacks into a log file."""
+        width = 70
+        border_width = 3
+        border_char = '='
+
+        def _blank_line():
+            return u'\n'
+
+        def _solid_line():
+            return u'{}\n'.format(border_char * width)
+
+        def _text_line(text):
+            text_width = width - (border_width + 1) * 2
+            return u'{} {} {}\n'.format(
+                border_char * border_width, text.center(text_width),
+                border_char * border_width)
+
+        with io.StringIO() as output:
+            output.write(_solid_line())
+            output.write(_text_line(u'Untranslated Strings'))
+            output.write(_solid_line())
+            output.write(_text_line(
+                u'{} occurrences of {} untranslated strings'.format(
+                    len(self.stacktraces), self.count_untranslated)))
+            output.write(_text_line(str(datetime.datetime.now())))
+            output.write(_solid_line())
+            output.write(_blank_line())
+
+            if not self.stacktraces:
+                output.write(
+                    _text_line(u'No untranslated strings found.'))
+                return output.getvalue().encode('utf-8')
+
+            for item in self.stacktraces:
+                output.write(u'{} :: {}\n'.format(item['locale'], item['id']))
+                for line in item['tb']:
+                    output.write(u'{}'.format(line))
+                output.write(_blank_line())
+
+            return output.getvalue().encode('utf-8')
+
     def tick(self, message, locale, default_locale):
+        """Count a translation."""
         if not message:
             return
 
@@ -57,9 +131,17 @@ class TranslationStats(object):
             messages[message.id] = 0
         messages[message.id] += 1
 
+        # Check for untranslated message.
         if not message.string and message.id.strip() and locale is not default_locale:
             if locale not in self._untranslated:
                 self._untranslated[locale] = set()
+
+            stack = traceback.format_stack()
+            self._stacktraces.append({
+                'locale': locale,
+                'id': message.id,
+                'tb': self._simplify_traceback(stack),
+            })
             self._untranslated[locale].add(message.id)
 
     def pretty_print(self, show_all=False):


### PR DESCRIPTION
Adding the ability to log the untranslated stack traces when finding untranslated strings.

Also updated export of untranslated strings to have the known pod_paths as locations of the string.