### PR TITLE
Periodical Update Check

### DIFF
--- a/grow/common/base_config.py
+++ b/grow/common/base_config.py
@@ -1,0 +1,33 @@
+"""Base Config control class."""
+
+
+class BaseConfig(object):
+    """Base class for identifier based configuration management."""
+
+    def __init__(self, config=None):
+        self._config = config or {}
+
+    @staticmethod
+    def _split_identifier(identifier):
+        return identifier.split('.')
+
+    def get(self, identifier, default_value=None):
+        """Retrieve the identifier value in the config."""
+        parts = self._split_identifier(identifier)
+        item = self._config
+        for part in parts:
+            if part not in item:
+                return default_value
+            item = item[part]
+        return item
+
+    def set(self, identifier, value):
+        """Set the value of the identifier in the config."""
+        parts = self._split_identifier(identifier)
+        key = parts.pop()
+        item = self._config
+        for part in parts:
+            if part not in item:
+                item[part] = {}
+            item = item[part]
+        item[key] = value

--- a/grow/common/base_config_test.py
+++ b/grow/common/base_config_test.py
@@ -1,0 +1,30 @@
+"""Tests for Base Config."""
+
+import unittest
+from grow.common import base_config
+
+
+class BaseConfigTestCase(unittest.TestCase):
+    """Test the RC Config."""
+
+    def setUp(self):
+        self.config = base_config.BaseConfig(config={})
+
+    def test_get_default(self):
+        """Test that get works on the config with default."""
+        self.assertEqual(42, self.config.get('foo', 42))
+
+        self.config.set('update.last_checked', 12345)
+        self.assertEqual(12, self.config.get('update.foo', 12))
+
+    def test_set_root(self):
+        """Test that set works on the config with root keys."""
+        self.assertEqual(None, self.config.get('foo'))
+        self.config.set('foo', 'bar')
+        self.assertEqual('bar', self.config.get('foo'))
+
+    def test_set_nested(self):
+        """Test that set works on the config with sub keys."""
+        self.assertEqual(None, self.config.get('update.last_checked'))
+        self.config.set('update.last_checked', 12345)
+        self.assertEqual(12345, self.config.get('update.last_checked'))

--- a/grow/common/rc_config.py
+++ b/grow/common/rc_config.py
@@ -1,0 +1,60 @@
+"""RC Config control class."""
+
+import datetime
+import os
+import time
+import yaml
+from grow.common import base_config
+
+
+RC_FILE_NAME = '.growrc.yaml'
+RC_LAST_CHECKED_DELTA = datetime.timedelta(hours=6)
+
+
+class RCConfig(base_config.BaseConfig):
+    """Config for Grow RC file."""
+
+    def __init__(self, config=None, internal_time=time.time):
+        super(RCConfig, self).__init__(config=config)
+        self._time = internal_time
+        if config is None:
+            self.read()
+
+    @property
+    def filename(self):
+        """Filename of the RC File."""
+        return os.path.expanduser('~/{}'.format(RC_FILE_NAME))
+
+    @property
+    def last_checked(self):
+        """Timestamp of the last time checked for sdk update."""
+        return self.get('update.last_checked', 0)
+
+    @last_checked.setter
+    def last_checked(self, value):
+        """Timestamp of the last time checked for sdk update."""
+        return self.set('update.last_checked', value)
+
+    @property
+    def needs_update_check(self):
+        """Check if the update check needs to be done."""
+        time_passed = self._time() - self.last_checked
+        return time_passed > RC_LAST_CHECKED_DELTA.total_seconds()
+
+    def read(self):
+        """Reads the RC config from the system."""
+        rc_file_name = self.filename
+        if not os.path.isfile(rc_file_name):
+            self._config = {}
+        with open(rc_file_name, 'r') as conf:
+            self._config = yaml.load(conf.read())
+
+    def reset_update_check(self):
+        """Reset the timestamp of the last_checked."""
+        self.last_checked = self._time()
+
+    def write(self):
+        """Writes the RC config to the system."""
+        rc_file_name = self.filename
+        with open(rc_file_name, 'w') as conf:
+            conf.write(yaml.safe_dump(self._config))

--- a/grow/common/rc_config.py
+++ b/grow/common/rc_config.py
@@ -20,6 +20,12 @@ class RCConfig(base_config.BaseConfig):
         if config is None:
             self.read()
 
+    @staticmethod
+    def _is_ci_env():
+        if 'CI' in os.environ:
+            return True
+        return False
+
     @property
     def filename(self):
         """Filename of the RC File."""
@@ -38,6 +44,8 @@ class RCConfig(base_config.BaseConfig):
     @property
     def needs_update_check(self):
         """Check if the update check needs to be done."""
+        if self._is_ci_env():
+            return False
         time_passed = self._time() - self.last_checked
         return time_passed > RC_LAST_CHECKED_DELTA.total_seconds()
 

--- a/grow/common/rc_config_test.py
+++ b/grow/common/rc_config_test.py
@@ -1,0 +1,32 @@
+"""Tests for RC Config."""
+
+import unittest
+from grow.common import rc_config
+
+
+def mock_time(value):
+    """Mock out the time value."""
+    def _mock():
+        return value
+    return _mock
+
+
+class RCConfigTestCase(unittest.TestCase):
+    """Test the RC Config."""
+
+    def _create_config(self, time_value=None):
+        self.config = rc_config.RCConfig(config={}, internal_time=mock_time(time_value))
+
+    def setUp(self):
+        self._create_config()
+
+    def test_last_checked(self):
+        """Test the last_checked."""
+        self.assertEqual(0, self.config.last_checked)
+        self.config.set('update.last_checked', 12345)
+        self.assertEqual(12345, self.config.last_checked)
+
+    def test_set(self):
+        """Test that set works on the config."""
+        self.config.set('update.last_checked', 12345)
+        self.assertEqual(12345, self.config.get('update.last_checked'))


### PR DESCRIPTION
Currently every time grow is run it checks for updates. This can be a bit excessive and when people are using grow a lot or using a shared IP it can cause API rate limiting by GitHub. To make this better this changes the SDK update check to run only every 6 hours. This causes a max of 4 checks a day instead of potentially hundreds of API calls to GitHub. GitHub will thank us...