### PR TITLE
Improving the local file deployment by using copy instead of read/write.

### DIFF
--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -1,8 +1,11 @@
-from . import base
-from protorpc import messages
+"""Local deployment destination."""
+
+import os
 from grow.pods import env
 from grow.pods.storage import storage as storage_lib
-import os
+from grow.deployments.destinations import base
+from protorpc import messages
+from shutil import copyfile
 
 
 class Config(messages.Message):
@@ -36,10 +39,11 @@ class LocalDestination(base.BaseDestination):
 
     def write_file(self, rendered_doc):
         path = rendered_doc.path
-        content = rendered_doc.read()
         out_path = os.path.join(self.out_dir, path.lstrip('/'))
-        fp = self.storage.write(out_path, content)
-        fp.close()
+        if rendered_doc.filename:
+            copyfile(rendered_doc.filename, path)
+        else:
+            self.storage.write(out_path, rendered_doc.read())
 
     def prelaunch(self, dry_run=False):
         for command in self.config.before_deploy:

--- a/grow/deployments/destinations/local.py
+++ b/grow/deployments/destinations/local.py
@@ -1,11 +1,11 @@
 """Local deployment destination."""
 
 import os
+import shutil
 from grow.pods import env
 from grow.pods.storage import storage as storage_lib
 from grow.deployments.destinations import base
 from protorpc import messages
-from shutil import copyfile
 
 
 class Config(messages.Message):
@@ -40,8 +40,8 @@ class LocalDestination(base.BaseDestination):
     def write_file(self, rendered_doc):
         path = rendered_doc.path
         out_path = os.path.join(self.out_dir, path.lstrip('/'))
-        if rendered_doc.filename:
-            copyfile(rendered_doc.filename, path)
+        if rendered_doc.file_path:
+            shutil.copyfile(rendered_doc.file_path, path)
         else:
             self.storage.write(out_path, rendered_doc.read())
 

--- a/grow/pods/storage/file_storage.py
+++ b/grow/pods/storage/file_storage.py
@@ -64,7 +64,6 @@ class FileStorage(base_storage.BaseStorage):
                 raise
         with cls.open(path, mode='w') as fp:
             fp.write(content)
-            return fp
 
     @staticmethod
     def exists(filename):

--- a/grow/pods/storage/file_storage.py
+++ b/grow/pods/storage/file_storage.py
@@ -62,10 +62,9 @@ class FileStorage(base_storage.BaseStorage):
                 pass
             else:
                 raise
-        fp = cls.open(path, mode='w')
-        fp.write(content)
-        fp.close()
-        return fp
+        with cls.open(path, mode='w') as fp:
+            fp.write(content)
+            return fp
 
     @staticmethod
     def exists(filename):

--- a/grow/rendering/rendered_document.py
+++ b/grow/rendering/rendered_document.py
@@ -19,23 +19,23 @@ class RenderedDocument(object):
         if content:
             self.write(content)
 
-    def _get_tmp_filename(self):
+    def _get_tmp_file_path(self):
         """Temp filename if has temporary dir."""
         return os.path.join(self.tmp_dir, self.hash)
 
     @property
-    def filename(self):
+    def file_path(self):
         """Returns the temp file name if available."""
         if not self.tmp_dir:
             return None
-        return self._get_tmp_filename()
+        return self._get_tmp_file_path()
 
     def read(self):
         """Reads the content when it needs it."""
         if not self.tmp_dir:
             return self._content
 
-        with open(self._get_tmp_filename(), "r") as tmp_file:
+        with open(self._get_tmp_file_path(), "r") as tmp_file:
             file_contents = tmp_file.read()
             if isinstance(file_contents, unicode):
                 file_contents = file_contents.encode('utf-8')
@@ -48,7 +48,7 @@ class RenderedDocument(object):
         self.hash = hashlib.sha1(content).hexdigest()
 
         if self.tmp_dir:
-            with open(self._get_tmp_filename(), "w") as tmp_file:
+            with open(self._get_tmp_file_path(), "w") as tmp_file:
                 tmp_file.write(content)
         else:
             self._content = content

--- a/grow/rendering/rendered_document.py
+++ b/grow/rendering/rendered_document.py
@@ -23,6 +23,13 @@ class RenderedDocument(object):
         """Temp filename if has temporary dir."""
         return os.path.join(self.tmp_dir, self.hash)
 
+    @property
+    def filename(self):
+        """Returns the temp file name if available."""
+        if not self.tmp_dir:
+            return None
+        return self._get_tmp_filename()
+
     def read(self):
         """Reads the content when it needs it."""
         if not self.tmp_dir:


### PR DESCRIPTION
Great improvement for local deployments.

With read/write deployment: `Deploying: 4457/4457 (in 0:01:00.1)`
With copy deployment: `Deploying: 4457/4457 (in 0:00:01.1)`

🚀 

Fixes #618 