### PR TITLE
Skip some locales from the translation processes.

### DIFF
--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import logging
+import os
 import threading
 import progressbar
 import texttable
@@ -53,6 +54,17 @@ class Translator(object):
         self.project_title = project_title or 'Untitled Grow Website'
         self.instructions = instructions
         self._inject = inject
+
+    @staticmethod
+    def _cleanup_symlinks(locales):
+        """Symlinked locales should be ignored."""
+        clean_locales = []
+        for locale in locales:
+            locale_path = 'translations/{}'.format(str(locale))
+            if os.path.islink(locale_path):
+                continue
+            clean_locales.append(locale)
+        return clean_locales
 
     def _download_content(self, stat):
         raise NotImplementedError
@@ -157,6 +169,7 @@ class Translator(object):
 
     def update_acl(self, locales=None):
         locales = locales or self.pod.catalogs.list_locales()
+        locales = self._cleanup_symlinks(locales)
         if not locales:
             self.pod.logger.info('No locales to found to update.')
             return
@@ -185,6 +198,7 @@ class Translator(object):
 
     def update_meta(self, locales=None):
         locales = locales or self.pod.catalogs.list_locales()
+        locales = self._cleanup_symlinks(locales)
         if not locales:
             self.pod.logger.info('No locales to found to update.')
             return
@@ -211,6 +225,7 @@ class Translator(object):
                prune=False):
         source_lang = self.pod.podspec.default_locale
         locales = locales or self.pod.catalogs.list_locales()
+        locales = self._cleanup_symlinks(locales)
         stats = []
         num_files = len(locales)
         if not locales:

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -55,13 +55,14 @@ class Translator(object):
         self.instructions = instructions
         self._inject = inject
 
-    @staticmethod
-    def _cleanup_symlinks(locales):
+    def _cleanup_symlinks(self, locales):
         """Symlinked locales should be ignored."""
         clean_locales = []
         for locale in locales:
             locale_path = 'translations/{}'.format(str(locale))
             if os.path.islink(locale_path):
+                self.pod.logger.info('Skipping: {} (symlinked)'.format(
+                    str(locale)))
                 continue
             clean_locales.append(locale)
         return clean_locales

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -86,10 +86,10 @@ class Translator(object):
         # Summary of skipped files.
         if skipped['symlink']:
             self.pod.logger.info('Skipping: {} (symlinked)'.format(
-                ', '.join(skipped['symlink'])))
+                ', '.join(sorted(skipped['symlink']))))
         if skipped['po']:
             self.pod.logger.info('Skipping: {} (no `.po` file)'.format(
-                ', '.join(skipped['po'])))
+                ', '.join(sorted(skipped['po']))))
 
         return clean_locales
 

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -74,7 +74,7 @@ class Translator(object):
 
             # Ignore the locales without a `.PO` file.
             po_path = os.path.join(locale_path, 'LC_MESSAGES', 'messages.po')
-            if not os.path.isfile(po_path):
+            if not self.pod.file_exists(po_path):
                 self.pod.logger.info('Skipping: {} (no `.po` file)'.format(
                     str(locale)))
                 continue

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -60,8 +60,8 @@ class Translator(object):
         clean_locales = []
         default_locale = self.pod.podspec.default_locale
         skipped = {
-            'symlink': [],
-            'po': [],
+            'symlink': set(),
+            'po': set(),
         }
         for locale in locales:
             locale_path = os.path.join('translations', str(locale))
@@ -72,13 +72,13 @@ class Translator(object):
 
             # Ignore the symlinks.
             if os.path.islink(locale_path):
-                skipped['symlink'].append(str(locale))
+                skipped['symlink'].add(str(locale))
                 continue
 
             # Ignore the locales without a `.PO` file.
             po_path = os.path.join(locale_path, 'LC_MESSAGES', 'messages.po')
             if not self.pod.file_exists(po_path):
-                skipped['po'].append(str(locale))
+                skipped['po'].add(str(locale))
                 continue
 
             clean_locales.append(locale)

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -59,6 +59,10 @@ class Translator(object):
         """Certain locales should be ignored."""
         clean_locales = []
         default_locale = self.pod.podspec.default_locale
+        skipped = {
+            'symlink': [],
+            'po': [],
+        }
         for locale in locales:
             locale_path = os.path.join('translations', str(locale))
 
@@ -68,18 +72,25 @@ class Translator(object):
 
             # Ignore the symlinks.
             if os.path.islink(locale_path):
-                self.pod.logger.info('Skipping: {} (symlinked)'.format(
-                    str(locale)))
+                skipped['symlink'].append(str(locale))
                 continue
 
             # Ignore the locales without a `.PO` file.
             po_path = os.path.join(locale_path, 'LC_MESSAGES', 'messages.po')
             if not self.pod.file_exists(po_path):
-                self.pod.logger.info('Skipping: {} (no `.po` file)'.format(
-                    str(locale)))
+                skipped['po'].append(str(locale))
                 continue
 
             clean_locales.append(locale)
+
+        # Summary of skipped files.
+        if skipped['symlink']:
+            self.pod.logger.info('Skipping: {} (symlinked)'.format(
+                ', '.join(skipped['symlink'])))
+        if skipped['po']:
+            self.pod.logger.info('Skipping: {} (no `.po` file)'.format(
+                ', '.join(skipped['po'])))
+
         return clean_locales
 
     def _download_content(self, stat):

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -58,8 +58,13 @@ class Translator(object):
     def _cleanup_locales(self, locales):
         """Certain locales should be ignored."""
         clean_locales = []
+        default_locale = self.pod.podspec.default_locale
         for locale in locales:
             locale_path = os.path.join('translations', str(locale))
+
+            # Silently ignore the default locale.
+            if default_locale and str(locale) == str(default_locale):
+                continue
 
             # Ignore the symlinks.
             if os.path.islink(locale_path):


### PR DESCRIPTION
For locales:

- Skip symlinks since it duplicates things.
- Skip default locale.
- Skip locales with missing `.po` files.

Example output:

```sh
[14:57:18] Skipping: de_AT, de_CH, en_AU, en_IE, en_SG, es_MX, es_PR, fr_CH, ms_SG, nl_BE, zh_Hans_SG (symlinked)
[14:57:18] Skipping: ca, da, de, en, es, fi, fr, it, ja, ko, nl, sv (no `.po` file)
```

Fixes #609 
Fixes #592 