### PR TITLE
Check for and use .nvmrc node version

### DIFF
--- a/grow/preprocessors/gulp.py
+++ b/grow/preprocessors/gulp.py
@@ -25,9 +25,16 @@ class GulpPreprocessor(base.BasePreprocessor):
             return
         args = sdk_utils.get_popen_args(self.pod)
         task = self.config.build_task if build else self.config.run_task
-        raw_command = '{} {}'.format(self.config.command, task)
-        command = shlex.split(raw_command)
-        process = subprocess.Popen(command, **args)
+        if sdk_utils.has_nvmrc(self.pod):
+            nvm_use_command = '{};'.format(
+                sdk_utils.format_nvm_shell_command('use'))
+        else:
+            nvm_use_command = ''
+
+        raw_command = '{} {} {}'.format(
+            nvm_use_command, self.config.command, task)
+
+        process = subprocess.Popen(raw_command, shell=True, **args)
         if not build:
             return
         code = process.wait()

--- a/grow/ui/package-lock.json
+++ b/grow/ui/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -295,9 +304,9 @@
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -322,6 +331,7 @@
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -343,7 +353,6 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -1747,13 +1756,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1761,6 +1763,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2439,10 +2448,10 @@
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -2651,15 +2660,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -3067,6 +3067,7 @@
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -3074,7 +3075,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.2.11",
         "resolve": "1.3.3",
@@ -3924,11 +3924,6 @@
         "readable-stream": "2.2.11"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3938,6 +3933,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4350,6 +4350,7 @@
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
           "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
           "requires": {
+            "JSONStream": "1.3.1",
             "assert": "1.4.1",
             "browser-pack": "6.0.2",
             "browser-resolve": "1.11.2",
@@ -4371,7 +4372,6 @@
             "https-browserify": "1.0.0",
             "inherits": "2.0.3",
             "insert-module-globals": "7.0.1",
-            "JSONStream": "1.3.1",
             "labeled-stream-splicer": "2.0.0",
             "module-deps": "4.1.1",
             "os-browserify": "0.1.2",


### PR DESCRIPTION
During 'grow install' the pod is checked for the presence of a .nvmrc file.
If one is present a subprocess sources nvm.sh and uses nvm to install the appropriate version.
During pre-processing the same approach is used to prefix the gulp command with a call to use the appropriate node version.