### PR TITLE
Add --no-include-obsolete option to download_translations command

### DIFF
--- a/grow/commands/subcommands/download_translations.py
+++ b/grow/commands/subcommands/download_translations.py
@@ -16,11 +16,12 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.download_translations')
 @shared.locale_option(help_text='Which locale(s) to download. If unspecified,'
                                 ' translations for all locales will be downloaded.')
 @shared.service_option
-def download_translations(pod_path, locale, service):
+@shared.include_obsolete_option(CFG, default_value=True)
+def download_translations(pod_path, locale, service, include_obsolete):
     """Downloads translations from a translation service."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     pod = pods.Pod(root, storage=storage.FileStorage)
     with pod.profile.timer('grow_download_translations'):
         translator = pod.get_translator(service)
-        translator.download(locales=locale)
+        translator.download(locales=locale, include_obsolete=include_obsolete)
     return pod

--- a/grow/commands/subcommands/download_translations.py
+++ b/grow/commands/subcommands/download_translations.py
@@ -16,7 +16,7 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.download_translations')
 @shared.locale_option(help_text='Which locale(s) to download. If unspecified,'
                                 ' translations for all locales will be downloaded.')
 @shared.service_option
-@shared.include_obsolete_option(CFG, default_value=True)
+@shared.include_obsolete_option(CFG, default_value=False)
 def download_translations(pod_path, locale, service, include_obsolete):
     """Downloads translations from a translation service."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))

--- a/grow/commands/subcommands/download_translations.py
+++ b/grow/commands/subcommands/download_translations.py
@@ -16,7 +16,7 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.download_translations')
 @shared.locale_option(help_text='Which locale(s) to download. If unspecified,'
                                 ' translations for all locales will be downloaded.')
 @shared.service_option
-@shared.include_obsolete_option(CFG, default_value=False)
+@shared.include_obsolete_option(CFG)
 def download_translations(pod_path, locale, service, include_obsolete):
     """Downloads translations from a translation service."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))

--- a/grow/commands/subcommands/import_translations.py
+++ b/grow/commands/subcommands/import_translations.py
@@ -15,7 +15,7 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.import_translations')
 @shared.pod_path_argument
 @click.option('--source', type=click.Path(), required=True,
               help='Path to source (either zip file, directory, or file).')
-@shared.include_obsolete_option(CFG, default_value=False)
+@shared.include_obsolete_option(CFG)
 @shared.locale_option(
     help_text='Locale of the message catalog to import. This option is'
               ' only applicable when --source is a .po file.', multiple=False)

--- a/grow/commands/subcommands/import_translations.py
+++ b/grow/commands/subcommands/import_translations.py
@@ -15,7 +15,7 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.import_translations')
 @shared.pod_path_argument
 @click.option('--source', type=click.Path(), required=True,
               help='Path to source (either zip file, directory, or file).')
-@shared.include_obsolete_option(CFG, default_value=True)
+@shared.include_obsolete_option(CFG, default_value=False)
 @shared.locale_option(
     help_text='Locale of the message catalog to import. This option is'
               ' only applicable when --source is a .po file.', multiple=False)

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -132,7 +132,7 @@ class Translator(object):
             stats_to_download[lang] = stat_message
         return stats_to_download
 
-    def download(self, locales, save_stats=True, inject=False, include_obsolete=True):
+    def download(self, locales, save_stats=True, inject=False, include_obsolete=False):
         # TODO: Rename to `download_and_import`.
         if not self.pod.file_exists(Translator.TRANSLATOR_STATS_PATH):
             text = 'File {} not found. Nothing to download.'

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -132,7 +132,7 @@ class Translator(object):
             stats_to_download[lang] = stat_message
         return stats_to_download
 
-    def download(self, locales, save_stats=True, inject=False):
+    def download(self, locales, save_stats=True, inject=False, include_obsolete=True):
         # TODO: Rename to `download_and_import`.
         if not self.pod.file_exists(Translator.TRANSLATOR_STATS_PATH):
             text = 'File {} not found. Nothing to download.'
@@ -187,7 +187,9 @@ class Translator(object):
             if inject:
                 if self.pod.catalogs.inject_translations(locale=lang, content=translations):
                     has_changed_content = True
-            elif self.pod.catalogs.import_translations(locale=lang, content=translations):
+            elif self.pod.catalogs.import_translations(
+                    locale=lang, content=translations,
+                    include_obsolete=include_obsolete):
                 has_changed_content = True
 
         if save_stats and has_changed_content:


### PR DESCRIPTION
Add --include-obsolete flag to download_translations command. The idea is we should be able to download translations from Sheets without including translations that might be obsolete/no longer used in the build. The translations can continue to live in Google Sheets if they're needed in the future (and can be removed with the --prune flag), but downloading with --no-include-obsolete should be the best way to download only what's needed.

@Zoramite do you think this should default to `False` when downloading from Google Sheets? That way, the regular usage is to only download what's needed.