### PR TITLE
Prefixing NVM commands with sourcing nvm.sh

### DIFF
--- a/grow/preprocessors/gulp.py
+++ b/grow/preprocessors/gulp.py
@@ -30,7 +30,7 @@ class GulpPreprocessor(base.BasePreprocessor):
         """Construct the command to run the given gulp task."""
         commands = [self.config.command, task]
         if self.pod.file_exists('/.nvmrc'):
-            commands = ['nvm run'] + commands
+            commands = [sdk_utils.get_nvm_command('use'), ';'] + commands
         return ' '.join(commands)
 
     def run(self, build=True):

--- a/grow/sdk/installers/nvm_installer.py
+++ b/grow/sdk/installers/nvm_installer.py
@@ -1,6 +1,8 @@
 """Nvm installer class."""
 
+import os
 import subprocess
+from grow.sdk import sdk_utils
 from grow.sdk.installers import base_installer
 
 
@@ -16,10 +18,7 @@ class NvmInstaller(base_installer.BaseInstaller):
 
     def check_prerequisites(self):
         """Check if required prerequisites are installed or available."""
-        status_command = 'nvm --version > /dev/null 2>&1'
-        not_found = subprocess.call(
-            status_command, **self.subprocess_args(shell=True)) == 127
-        if not_found:
+        if 'NVM_DIR' not in os.environ:
             install_commands = [
                 'Download nvm from https://github.com/creationix/nvm']
             raise base_installer.MissingPrerequisiteError(
@@ -27,12 +26,12 @@ class NvmInstaller(base_installer.BaseInstaller):
 
     def install(self):
         """Install dependencies."""
-        install_command = 'nvm install'
+        install_command = sdk_utils.get_nvm_command('install')
         process = subprocess.Popen(
             install_command, **self.subprocess_args(shell=True))
         code = process.wait()
         if not code:
-            use_command = 'nvm use'
+            use_command = sdk_utils.get_nvm_command('use')
             process = subprocess.Popen(
                 use_command, **self.subprocess_args(shell=True))
             code = process.wait()

--- a/grow/sdk/sdk_utils.py
+++ b/grow/sdk/sdk_utils.py
@@ -4,6 +4,8 @@ import os
 import platform
 from grow.common import config
 
+# To handle sourcing nvm in shell sessions
+NVM_COMMAND = '. $NVM_DIR/nvm.sh; nvm'
 
 VERSION = config.VERSION
 PLATFORM = None
@@ -29,3 +31,7 @@ def subprocess_args(pod, shell=False):
     if shell or PLATFORM == 'win':
         args['shell'] = True
     return args
+
+
+def get_nvm_command(task):
+    return ' '.join([NVM_COMMAND, task])


### PR DESCRIPTION
The only way I've been able to get this to run reliably with a .nvmrc file with the basic setup of nvm using the install script laid out in the repo is to source it as part of grow.

There's probably a way I can resolve this on my system, but my thinking is that it'd be easiest for users if grow works with the basic nvm install script.

I adjusted the pre-requisite check to look for the NVM_DIR value in env as evidence that the install script for nvm has been run as expected as the remainder assumes its presence. I could add a check for the nvm.sh file inside as well but I thought that might be overkill.

What do you think?