### PR TITLE
Copy objects to defend against easily encounterable deeptrans bugs.

### DIFF
--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -1,6 +1,7 @@
 """Template jinja filters."""
 
 from datetime import datetime
+import copy
 import json as json_lib
 import random
 import re
@@ -40,7 +41,11 @@ def _deep_gettext(ctx, fields):
 @jinja2.contextfilter
 def deeptrans(ctx, obj):
     """Deep translate an object."""
-    return _deep_gettext(ctx, obj)
+    # Avoid issues (related to sharing the same object across locales and
+    # leaking translations from one locale to another) by copying the object
+    # before it's sent to deeptrans.
+    new_item = copy.deepcopy(obj)
+    return _deep_gettext(ctx, new_item)
 
 @jinja2.contextfilter
 def expand_partial(_ctx, partial_name):


### PR DESCRIPTION
It's a bit bizarre since I've used `deeptrans` on projects before but never encountered this bug. The bug may have cropped up due to caching (like file caching) from `g.json` in the template.

Attempts to duplicate the lists and objects before passing them to `deeptrans` didn't do anything, but copying the objects here seems to have fixed the issue.

/cc @aclabaugh 