### PR TITLE
Fixing the markdown url syntax to work with multiple urls in a line.

### DIFF
--- a/grow/common/markdown_extensions.py
+++ b/grow/common/markdown_extensions.py
@@ -95,7 +95,7 @@ class IncludeExtension(extensions.Extension):
 
 class UrlPreprocessor(preprocessors.Preprocessor):
 
-    REGEX = re.compile("\[url\('([^')]*)'\)\]")
+    REGEX = re.compile("\[url\('([^']*)'\)\]")
 
     def __init__(self, pod, markdown_instance):
         self.pod = pod
@@ -110,7 +110,7 @@ class UrlPreprocessor(preprocessors.Preprocessor):
             else:
                 for pod_path in pod_paths:
                     doc = self.pod.get_doc(pod_path)
-                    line = re.sub(UrlPreprocessor.REGEX, doc.url.path, line)
+                    line = re.sub(UrlPreprocessor.REGEX, doc.url.path, line, count=1)
                 new_lines.append(line)
         return new_lines
 

--- a/grow/common/markdown_extensions_test.py
+++ b/grow/common/markdown_extensions_test.py
@@ -95,6 +95,51 @@ class TocExtensionTestCase(unittest.TestCase):
         self.assertIn(header, result)
 
 
+class UrlPreprocessorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.pod = testing.create_pod()
+        self.pod.write_yaml('/podspec.yaml', {})
+        self.pod.write_yaml('/content/pages/_blueprint.yaml', {
+            '$view': '/views/base.html',
+            '$path': '/{base}/'
+        })
+        self.pod.write_file('/content/pages/test1.md', 'Testing')
+        self.pod.write_file('/content/pages/test2.md', 'Testing')
+
+    def test_url(self):
+        """Plain url reference works."""
+        content = 'URL:[url(\'/content/pages/test1.md\')]'
+        self.pod.write_file('/content/pages/test.md', content)
+        content = '{{doc.html|safe}}'
+        self.pod.write_file('/views/base.html', content)
+        controller, params = self.pod.match('/test/')
+        result = controller.render(params)
+        self.assertIn('URL:/test1', result)
+
+    def test_url_link(self):
+        """Plain url reference works."""
+        content = '[Link]([url(\'/content/pages/test1.md\')])'
+        self.pod.write_file('/content/pages/test.md', content)
+        content = '{{doc.html|safe}}'
+        self.pod.write_file('/views/base.html', content)
+        controller, params = self.pod.match('/test/')
+        result = controller.render(params)
+        self.assertIn('href="/test1/"', result)
+
+    def test_url_link_multiple(self):
+        """Plain url reference works."""
+        content = ('[Link]([url(\'/content/pages/test1.md\')])'
+                   '[Link]([url(\'/content/pages/test2.md\')])')
+        self.pod.write_file('/content/pages/test.md', content)
+        content = '{{doc.html|safe}}'
+        self.pod.write_file('/views/base.html', content)
+        controller, params = self.pod.match('/test/')
+        result = controller.render(params)
+        self.assertIn('href="/test1/"', result)
+        self.assertIn('href="/test2/"', result)
+
+
 class CodeBlockPreprocessorTestCase(unittest.TestCase):
 
     def test_noclasses(self):


### PR DESCRIPTION
When using the `[url('/content/pages/test.md')]` format to link to other grow docs it was too greedy in the replace and caused all the links in the line to be replaced by whatever the first link was.