### PR TITLE
Fixing the environment configuration defaults.

### DIFF
--- a/grow/pods/env.py
+++ b/grow/pods/env.py
@@ -25,7 +25,7 @@ class Env(object):
         self.name = config.name
         self.config = config
         self.host = config.host
-        self.port = config.port or 80
+        self.port = config.port
         self.scheme = config.scheme or 'http'
         self.cached = config.cached
         self.fingerprint = config.fingerprint or str(int(time.time()))
@@ -43,7 +43,7 @@ class Env(object):
 
     @property
     def port(self):
-        return self.config.port or 80
+        return self.config.port
 
     @port.setter
     def port(self, value):
@@ -51,7 +51,7 @@ class Env(object):
 
     @property
     def scheme(self):
-        return self.config.scheme or 'https'
+        return self.config.scheme
 
     @scheme.setter
     def scheme(self, value):

--- a/grow/pods/env.py
+++ b/grow/pods/env.py
@@ -26,7 +26,7 @@ class Env(object):
         self.config = config
         self.host = config.host
         self.port = config.port
-        self.scheme = config.scheme or 'http'
+        self.scheme = config.scheme
         self.cached = config.cached
         self.fingerprint = config.fingerprint or str(int(time.time()))
 

--- a/grow/pods/env_test.py
+++ b/grow/pods/env_test.py
@@ -11,8 +11,8 @@ class EnvTest(unittest.TestCase):
         config = env.EnvConfig(host='localhost')
         environment = env.Env(config)
         self.assertEqual('localhost', environment.host)
-        self.assertEqual('http', environment.scheme)
-        self.assertEqual(80, environment.port)
+        self.assertEqual(None, environment.scheme)
+        self.assertEqual(None, environment.port)
 
     def test_constructor_full(self):
         config = env.EnvConfig(host='remotehost', scheme='https', port=443)


### PR DESCRIPTION
The defaults for the environment config are conflicting with being able to set simple configurations.

The URL object itself should be able to handle the defaults and is more fluid with how it deals with using either a port or the scheme.