### PR TITLE
Adding Render Pool Batches

### DIFF
--- a/grow/commands/shared.py
+++ b/grow/commands/shared.py
@@ -150,3 +150,16 @@ def service_option(func):
     return click.option('--service', '-s', type=str,
                         help='Name of the translator service to use. This option is'
                         ' only required if more than one service is configured.')(func)
+
+
+def threaded_option(config):
+    """Option for using threading when rendering."""
+    shared_default = CFG.get('threaded', True)
+    config_default = config.get('threaded', shared_default)
+
+    def _decorator(func):
+        return click.option(
+            '--threaded/--no-threaded', '-t/-nt', is_flag=True,
+            default=config_default,
+            help='Use threading during rendering pipeline.')(func)
+    return _decorator

--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -30,8 +30,9 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.build')
 @shared.out_dir_option(CFG)
 @shared.preprocess_option(CFG)
 @shared.reroute_option(CFG)
+@shared.threaded_option(CFG)
 def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
-          locate_untranslated, deployment, use_reroute):
+          locate_untranslated, deployment, use_reroute, threaded):
     """Generates static files and dumps them to a local destination."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     out_dir = out_dir or os.path.join(root, 'build')
@@ -68,7 +69,8 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
                 content_generator = renderer.Renderer.rendered_docs(pod, pod.router.routes)
             else:
                 paths, _ = pod.determine_paths_to_build(pod_paths=pod_paths)
-                content_generator = destination.dump(pod, pod_paths=pod_paths)
+                content_generator = destination.dump(
+                    pod, pod_paths=pod_paths, use_threading=threaded)
             stats_obj = stats.Stats(pod, paths=paths)
             destination.deploy(
                 content_generator, stats=stats_obj, repo=repo, confirm=False,

--- a/grow/commands/subcommands/deploy.py
+++ b/grow/commands/subcommands/deploy.py
@@ -30,9 +30,10 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.deploy')
 @shared.force_untranslated_option(CFG)
 @shared.preprocess_option(CFG)
 @shared.reroute_option(CFG)
+@shared.threaded_option(CFG)
 @click.pass_context
 def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
-           test_only, auth, force_untranslated, use_reroute):
+           test_only, auth, force_untranslated, use_reroute, threaded):
     """Deploys a pod to a destination."""
     if auth:
         text = ('--auth must now be specified before deploy. Usage:'
@@ -59,7 +60,7 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
             if test_only:
                 deployment.test()
                 return
-            content_generator = deployment.dump(pod)
+            content_generator = deployment.dump(pod, use_threading=threaded)
             repo = utils.get_git_repo(pod.root)
             if use_reroute:
                 pod.router.use_simple()

--- a/grow/commands/subcommands/stage.py
+++ b/grow/commands/subcommands/stage.py
@@ -29,9 +29,10 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.stage')
 @shared.force_untranslated_option(CFG)
 @shared.preprocess_option(CFG)
 @shared.reroute_option(CFG)
+@shared.threaded_option(CFG)
 @click.pass_context
 def stage(context, pod_path, remote, preprocess, subdomain, api_key,
-          force_untranslated, use_reroute):
+          force_untranslated, use_reroute, threaded):
     """Stages a build on a WebReview server."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     auth = context.parent.params.get('auth')
@@ -51,7 +52,7 @@ def stage(context, pod_path, remote, preprocess, subdomain, api_key,
                 deployment.login(auth)
             if preprocess:
                 pod.preprocess()
-            content_generator = deployment.dump(pod)
+            content_generator = deployment.dump(pod, use_threading=threaded)
             repo = utils.get_git_repo(pod.root)
             if use_reroute:
                 pod.router.use_simple()

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -265,9 +265,9 @@ class BaseDestination(object):
     def login(self, account, reauth=False):
         pass
 
-    def dump(self, pod, pod_paths=None):
+    def dump(self, pod, pod_paths=None, use_threading=True):
         pod.set_env(self.get_env())
-        return pod.dump(pod_paths=pod_paths)
+        return pod.dump(pod_paths=pod_paths, use_threading=use_threading)
 
     def deploy(self, content_generator, stats=None, repo=None, dry_run=False,
                confirm=False, test=True, is_partial=False, require_translations=False):

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -384,9 +384,11 @@ class Pod(object):
         """Disable a grow feature."""
         self._features.disable(feature)
 
-    def dump(self, suffix='index.html', append_slashes=True, pod_paths=None):
+    def dump(self, suffix='index.html', append_slashes=True, pod_paths=None, use_threading=True):
+        """Dumps the pod, yielding rendered_doc based on pod routes."""
         for rendered_doc in self.export(
-                suffix=suffix, append_slashes=append_slashes, pod_paths=pod_paths):
+                suffix=suffix, append_slashes=append_slashes, pod_paths=pod_paths,
+                use_threading=use_threading):
             yield rendered_doc
         if self.ui and self.is_enabled(self.FEATURE_UI):
             for rendered_doc in self.export_ui():
@@ -396,10 +398,11 @@ class Pod(object):
         """Enable a grow feature."""
         self._features.enable(feature)
 
-    def export(self, suffix=None, append_slashes=False, pod_paths=None):
-        """Builds the pod, returning a mapping of paths to content based on pod routes."""
+    def export(self, suffix=None, append_slashes=False, pod_paths=None, use_threading=True):
+        """Builds the pod, yielding rendered_doc based on pod routes."""
         if self.use_reroute:
-            for rendered_doc in renderer.Renderer.rendered_docs(self, self.router.routes):
+            for rendered_doc in renderer.Renderer.rendered_docs(
+                    self, self.router.routes, use_threading=use_threading):
                 yield rendered_doc
         else:
             paths, routes = self.determine_paths_to_build(pod_paths=pod_paths)

--- a/grow/rendering/render_batch.py
+++ b/grow/rendering/render_batch.py
@@ -72,12 +72,12 @@ class RenderBatches(object):
         batch = self._get_batch(controller.locale)
         batch.add(controller, *args, **kwargs)
 
-    def render(self):
+    def render(self, use_threading=True):
         """Render all of the batches."""
         render_errors = []
         rendered_docs = []
 
-        if not ThreadPool:
+        if not ThreadPool or not use_threading:
             for _, batch in self._batches.iteritems():
                 docs, errors = batch.render_sync()
                 render_errors = render_errors + errors

--- a/grow/rendering/render_batch.py
+++ b/grow/rendering/render_batch.py
@@ -1,0 +1,190 @@
+"""Renderer for performing render operations for the pod."""
+
+import sys
+from grow.common import utils
+
+if utils.is_appengine():
+    # pylint: disable=invalid-name
+    ThreadPool = None  # pragma: no cover
+else:
+    from multiprocessing.dummy import Pool as ThreadPool
+
+
+class Error(Exception):
+    """Base renderer error."""
+    pass
+
+
+class RenderError(Error):
+    """Errors that occured during the rendering."""
+
+    def __init__(self, message, err, err_tb):
+        super(RenderError, self).__init__(message)
+        self.err = err
+        self.err_tb = err_tb
+
+
+class RenderNotStartedError(Error):
+    """Rendering was not started."""
+    pass
+
+
+def render_func(batch):
+    """Render the controller."""
+    result = RenderBatchResult()
+    for item in batch:
+        controller = item['controller']
+        try:
+            result.rendered_docs.append(controller.render(
+                jinja_env=item['jinja_env']))
+        # pylint: disable=broad-except
+        except Exception as err:
+            _, _, err_tb = sys.exc_info()
+            result.render_errors.append(RenderError(
+                "Error rendering {}".format(controller.serving_path),
+                err, err_tb))
+    return result
+
+
+class RenderBatches(object):
+    """Handles the batching of rendering."""
+
+    def __init__(self, render_pool, profile, tick=None):
+        self.profile = profile
+        self.render_pool = render_pool
+        self.tick = tick
+        self._batches = {}
+
+    def __len__(self):
+        count = 0
+        for _, batch in self._batches.iteritems():
+            count = count + len(batch)
+        return count
+
+    def _get_batch(self, locale):
+        if locale not in self._batches:
+            self._batches[locale] = RenderLocaleBatch(
+                self.render_pool.get_jinja_env(locale), self.profile, tick=self.tick)
+        return self._batches[locale]
+
+    def add(self, controller, *args, **kwargs):
+        """Add an item to be rendered to the batch."""
+        batch = self._get_batch(controller.locale)
+        batch.add(controller, *args, **kwargs)
+
+    def render(self):
+        """Render all of the batches."""
+        render_errors = []
+        rendered_docs = []
+
+        if not ThreadPool:
+            for _, batch in self._batches.iteritems():
+                docs, errors = batch.render_sync()
+                render_errors = render_errors + errors
+                rendered_docs = rendered_docs + docs
+        else:
+            for _, batch in self._batches.iteritems():
+                batch.render_start()
+            for _, batch in self._batches.iteritems():
+                docs, errors = batch.render_finish()
+                render_errors = render_errors + errors
+                rendered_docs = rendered_docs + docs
+
+        return rendered_docs, render_errors
+
+
+class RenderLocaleBatch(object):
+    """Handles the rendering and threading of the controllers."""
+
+    BATCH_MAX_SIZE = 300  # Maximum number of documents in a batch.
+
+    def __init__(self, jinja_env, profile, tick=None):
+        self.jinja_env = jinja_env
+        self.profile = profile
+        self.tick = tick
+        self.batches = [[]]
+        self._is_rendering = False
+        self._results = None
+        self._thread_pool = None
+
+    def __len__(self):
+        count = 0
+        for batch in self.batches:
+            count = count + len(batch)
+        return count
+
+    def _get_batch(self):
+        # Ensure that batch is not over the max size.
+        batch = self.batches[len(self.batches) - 1]
+        if len(batch) >= self.BATCH_MAX_SIZE:
+            self.batches.append([])
+            batch = self.batches[len(self.batches) - 1]
+        return batch
+
+    def add(self, controller, *args, **kwargs):
+        """Add an item to be rendered to the batch."""
+        batch = self._get_batch()
+
+        batch.append({
+            'controller': controller,
+            'jinja_env': self.jinja_env,
+            'args': args,
+            'kwargs': kwargs,
+        })
+
+    def render_start(self):
+        """Start the batches rendering."""
+        self._thread_pool = ThreadPool(len(self.batches))
+        self._results = self._thread_pool.imap_unordered(
+            render_func, self.batches)
+        self._is_rendering = True
+
+    def render_finish(self):
+        """Finish in progress batches rendering."""
+        if not self._is_rendering:
+            raise RenderNotStartedError('Rendering was never started')
+
+        render_errors = []
+        rendered_docs = []
+
+        for batch_result in self._results:
+            render_errors = render_errors + batch_result.render_errors
+            rendered_docs = rendered_docs + batch_result.rendered_docs
+            if self.tick:
+                for _ in batch_result.render_errors:
+                    self.tick()
+                for _ in batch_result.rendered_docs:
+                    self.tick()
+            for result in batch_result.rendered_docs:
+                self.profile.add_timer(result.render_timer)
+
+        self._thread_pool.close()
+        self._thread_pool.join()
+        self._is_rendering = False
+
+        return rendered_docs, render_errors
+
+    def render_sync(self):
+        """Syncronous rendering for non-threaded rendering."""
+        render_errors = []
+        rendered_docs = []
+
+        for batch in self.batches:
+            batch_result = render_func(batch)
+            render_errors = render_errors + batch_result.render_errors
+            rendered_docs = rendered_docs + batch_result.rendered_docs
+            if self.tick:
+                for _ in batch_result.render_errors:
+                    self.tick()
+                for _ in batch_result.rendered_docs:
+                    self.tick()
+
+        return rendered_docs, render_errors
+
+
+class RenderBatchResult(object):
+    """Results from a batched rendering."""
+
+    def __init__(self):
+        self.render_errors = []
+        self.rendered_docs = []

--- a/grow/rendering/render_batch_test.py
+++ b/grow/rendering/render_batch_test.py
@@ -28,15 +28,12 @@ class RendererTestCase(unittest.TestCase):
 
         self.assertEqual(len(routes), len(self.batches))
 
-        # No errors while rendering.
-        self.batches.render()
-
-    def test_render_batches_batch_max(self):
-        """Breaks up the rendering into max sized batches."""
+    def test_render_batches_batch_size(self):
+        """Breaks up the rendering into specific sized batches."""
         self.pod.router.add_all()
 
         # Set a lower max batch size for tests.
-        render_batch.RenderLocaleBatch.BATCH_MAX_SIZE = 3
+        self.batches.batch_size = 3
 
         routes = self.pod.router.routes
         for controller in renderer.Renderer.controller_generator(self.pod, routes):

--- a/grow/rendering/render_batch_test.py
+++ b/grow/rendering/render_batch_test.py
@@ -1,0 +1,49 @@
+"""Tests for the render batch."""
+
+import unittest
+from grow.pods import pods
+from grow.pods import storage
+from grow.rendering import render_batch
+from grow.rendering import renderer
+from grow.testing import testing
+
+
+class RendererTestCase(unittest.TestCase):
+    """Test the renderer."""
+
+    def setUp(self):
+        self.dir_path = testing.create_test_pod_dir()
+        self.pod = pods.Pod(
+            self.dir_path, storage=storage.FileStorage, use_reroute=True)
+        self.batches = render_batch.RenderBatches(
+            self.pod.render_pool, self.pod.profile)
+
+    def test_render_batches(self):
+        """Renders the docs without errors."""
+        self.pod.router.add_all()
+
+        routes = self.pod.router.routes
+        for controller in renderer.Renderer.controller_generator(self.pod, routes):
+            self.batches.add(controller)
+
+        self.assertEqual(len(routes), len(self.batches))
+
+        # No errors while rendering.
+        self.batches.render()
+
+    def test_render_batches_batch_max(self):
+        """Breaks up the rendering into max sized batches."""
+        self.pod.router.add_all()
+
+        # Set a lower max batch size for tests.
+        self.batches.BATCH_MAX_SIZE = 10
+
+        routes = self.pod.router.routes
+        for controller in renderer.Renderer.controller_generator(self.pod, routes):
+            self.batches.add(controller)
+
+        self.assertEqual(len(routes), len(self.batches))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/grow/rendering/render_batch_test.py
+++ b/grow/rendering/render_batch_test.py
@@ -36,13 +36,19 @@ class RendererTestCase(unittest.TestCase):
         self.pod.router.add_all()
 
         # Set a lower max batch size for tests.
-        self.batches.BATCH_MAX_SIZE = 10
+        self.batches.BATCH_MAX_SIZE = 3
 
         routes = self.pod.router.routes
         for controller in renderer.Renderer.controller_generator(self.pod, routes):
             self.batches.add(controller)
 
         self.assertEqual(len(routes), len(self.batches))
+
+    def test_render_batch_not_started(self):
+        """Breaks up the rendering into max sized batches."""
+        batch = render_batch.RenderLocaleBatch(None, None)
+        with self.assertRaises(render_batch.RenderNotStartedError):
+            batch.render_finish()
 
 
 if __name__ == '__main__':

--- a/grow/rendering/render_batch_test.py
+++ b/grow/rendering/render_batch_test.py
@@ -36,7 +36,7 @@ class RendererTestCase(unittest.TestCase):
         self.pod.router.add_all()
 
         # Set a lower max batch size for tests.
-        self.batches.BATCH_MAX_SIZE = 3
+        render_batch.RenderLocaleBatch.BATCH_MAX_SIZE = 3
 
         routes = self.pod.router.routes
         for controller in renderer.Renderer.controller_generator(self.pod, routes):

--- a/grow/rendering/renderer.py
+++ b/grow/rendering/renderer.py
@@ -25,7 +25,7 @@ class Renderer(object):
 
     # pylint: disable=too-many-locals
     @staticmethod
-    def rendered_docs(pod, routes):
+    def rendered_docs(pod, routes, use_threading=True):
         """Generate the rendered documents for the given routes."""
         with pod.profile.timer('renderer.Renderer.render_docs'):
             routes_len = len(routes)
@@ -45,7 +45,8 @@ class Renderer(object):
             for controller in Renderer.controller_generator(pod, routes):
                 batches.add(controller)
 
-            rendered_docs, render_errors = batches.render()
+            rendered_docs, render_errors = batches.render(
+                use_threading=use_threading)
             progress.finish()
 
             if render_errors:

--- a/grow/rendering/renderer.py
+++ b/grow/rendering/renderer.py
@@ -21,9 +21,7 @@ class RenderErrors(Error):
 
 class Renderer(object):
     """Handles the rendering and threading of the controllers."""
-    POOL_SIZE = 20  # Thread pool size for rendering.
 
-    # pylint: disable=too-many-locals
     @staticmethod
     def rendered_docs(pod, routes, use_threading=True):
         """Generate the rendered documents for the given routes."""

--- a/grow/rendering/renderer.py
+++ b/grow/rendering/renderer.py
@@ -1,30 +1,14 @@
 """Renderer for performing render operations for the pod."""
 
-import sys
 import traceback
 import progressbar
 from grow.common import progressbar_non
-from grow.common import utils
-
-if utils.is_appengine():
-    # pylint: disable=invalid-name
-    ThreadPool = None  # pragma: no cover
-else:
-    from multiprocessing.dummy import Pool as ThreadPool  # pylint: disable=unused-import
+from grow.rendering import render_batch
 
 
 class Error(Exception):
     """Base renderer error."""
     pass
-
-
-class RenderError(Error):
-    """Errors that occured during the rendering."""
-
-    def __init__(self, message, err, err_tb):
-        super(RenderError, self).__init__(message)
-        self.err = err
-        self.err_tb = err_tb
 
 
 class RenderErrors(Error):
@@ -39,45 +23,11 @@ class Renderer(object):
     """Handles the rendering and threading of the controllers."""
     POOL_SIZE = 20  # Thread pool size for rendering.
 
-    @staticmethod
-    def _handle_render_errors(render_errors):
-        if render_errors:
-            for error in render_errors:
-                print error.message
-                print error.err.message
-                traceback.print_tb(error.err_tb)
-                print ''
-            text = 'There were {} errors during rendering.'
-            raise RenderErrors(text.format(
-                len(render_errors)), render_errors)
-
     # pylint: disable=too-many-locals
     @staticmethod
     def rendered_docs(pod, routes):
         """Generate the rendered documents for the given routes."""
-        cont_generator = Renderer.controller_generator(pod, routes)
-
-        # Turn off the pooling until it becomes faster than not pooling.
-        # pylint: disable=redefined-outer-name, invalid-name
-        ThreadPool = None
-
         with pod.profile.timer('renderer.Renderer.render_docs'):
-            # Preload the render_pool before attempting to use.
-            _ = pod.render_pool
-            render_errors = []
-
-            def render_func(args):
-                """Render the content."""
-                controller = args['controller']
-                try:
-                    return controller.render(jinja_env=args['jinja_env'])
-                # pylint: disable=broad-except
-                except Exception as err:
-                    _, _, err_tb = sys.exc_info()
-                    return RenderError(
-                        "Error rendering {}".format(controller.serving_path),
-                        err, err_tb)
-
             routes_len = len(routes)
             text = 'Building: %(value)d/{} (in %(time_elapsed).9s)'
             widgets = [progressbar.FormatLabel(text.format(routes_len))]
@@ -85,49 +35,28 @@ class Renderer(object):
                 "Building pod...", widgets=widgets, max_value=routes_len)
             progress.start()
 
-            rendered_docs = []
-            if not ThreadPool:
-                for controller in cont_generator:
-                    jinja_env = pod.render_pool.get_jinja_env(
-                        controller.locale) if controller.use_jinja else None
-                    result = render_func({
-                        'controller': controller,
-                        'jinja_env': jinja_env,
-                    })
-                    if isinstance(result, Exception):
-                        render_errors.append(result)
-                    else:
-                        rendered_docs.append(result)
-                    progress.update(progress.value + 1)
-                progress.finish()
-                Renderer._handle_render_errors(render_errors)
-                return rendered_docs
-
-            pod.render_pool.pool_size = Renderer.POOL_SIZE
-
-            # pylint: disable=not-callable
-            thread_pool = ThreadPool(Renderer.POOL_SIZE)
-            threaded_args = []
-            for controller in cont_generator:
-                jinja_env = pod.render_pool.get_jinja_env(
-                    controller.doc.locale) if controller.use_jinja else None
-                threaded_args.append({
-                    'controller': controller,
-                    'jinja_env': jinja_env,
-                })
-            results = thread_pool.imap_unordered(render_func, threaded_args)
-
-            for result in results:
-                if isinstance(result, Exception):
-                    render_errors.append(result)
-                else:
-                    pod.profile.add_timer(result.render_timer)
+            def tick():
+                """Tick the progress bar value."""
                 progress.update(progress.value + 1)
-            thread_pool.close()
-            thread_pool.join()
+
+            batches = render_batch.RenderBatches(
+                pod.render_pool, pod.profile, tick=tick)
+
+            for controller in Renderer.controller_generator(pod, routes):
+                batches.add(controller)
+
+            rendered_docs, render_errors = batches.render()
             progress.finish()
 
-            Renderer._handle_render_errors(render_errors)
+            if render_errors:
+                for error in render_errors:
+                    print error.message
+                    print error.err.message
+                    traceback.print_tb(error.err_tb)
+                    print ''
+                text = 'There were {} errors during rendering.'
+                raise RenderErrors(text.format(
+                    len(render_errors)), render_errors)
             return rendered_docs
 
     @staticmethod

--- a/grow/rendering/renderer_test.py
+++ b/grow/rendering/renderer_test.py
@@ -23,9 +23,15 @@ class RendererTestCase(unittest.TestCase):
         routes = self.pod.router.routes
         self.render.rendered_docs(self.pod, routes)
 
+    def test_renderer_sans_threading(self):
+        """Renders the docs without threading."""
+        self.pod.router.add_all()
+        routes = self.pod.router.routes
+        self.render.rendered_docs(self.pod, routes, use_threading=False)
+
     @mock.patch.object(render_controller.RenderDocumentController, 'render')
     def test_render(self, mock_render):
-        """Renders the docs without errors."""
+        """Renders the docs with errors."""
         mock_render.side_effect = ValueError()
 
         self.pod.router.add_all()


### PR DESCRIPTION
Breaking up the rendering to be in batches that are threaded. In large sites this can bring down the render time by up to 20%.