### PR TITLE
Locale filtering during build

### DIFF
--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -76,9 +76,10 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
                 content_generator = destination.dump(
                     pod, pod_paths=pod_paths, use_threading=threaded)
             stats_obj = stats.Stats(pod, paths=paths)
+            is_partial = bool(pod_paths) or bool(locale)
             destination.deploy(
                 content_generator, stats=stats_obj, repo=repo, confirm=False,
-                test=False, is_partial=bool(pod_paths))
+                test=False, is_partial=is_partial)
 
             pod.podcache.write()
     except pods.Error as err:

--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -26,13 +26,14 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.build')
 @click.option('--locate-untranslated',
               default=CFG.get('locate-untranslated', False), is_flag=True,
               help='Shows untranslated message information.')
+@shared.locale_option(help_text='Filter build routes to specific locale.')
 @shared.deployment_option(CFG)
 @shared.out_dir_option(CFG)
 @shared.preprocess_option(CFG)
 @shared.reroute_option(CFG)
 @shared.threaded_option(CFG)
 def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
-          locate_untranslated, deployment, use_reroute, threaded):
+          locate_untranslated, deployment, use_reroute, threaded, locale):
     """Generates static files and dumps them to a local destination."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     out_dir = out_dir or os.path.join(root, 'build')
@@ -65,6 +66,8 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
                     pod.router.add_pod_paths(pod_paths)
                 else:
                     pod.router.add_all()
+                if locale:
+                    pod.router.filter(locales=list(locale))
                 paths = pod.router.routes.paths
                 content_generator = renderer.Renderer.rendered_docs(
                     pod, pod.router.routes, use_threading=threaded)

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -187,6 +187,20 @@ class Router(object):
             docs = self._preload_and_expand(docs, expand=concrete)
             self.add_docs(docs, concrete=concrete)
 
+    def filter(self, locales=None):
+        """Filter the routes based on a criteria."""
+        if locales:
+            # Ability to specify a none locale using commanf flag.
+            if 'None' in locales:
+                print 'adding None'
+                locales.append(None)
+            def _filter_locales(route_info):
+                if 'locale' in route_info.meta:
+                    return route_info.meta['locale'] in locales
+                # Build non-locale based routes with none locale.
+                return None in locales
+            self.routes.filter(_filter_locales)
+
     def get_render_controller(self, path, route_info, params=None):
         """Find the correct render controller for the given route info."""
         return render_controller.RenderController.from_route_info(

--- a/grow/routing/router_test.py
+++ b/grow/routing/router_test.py
@@ -7,7 +7,7 @@ from grow.routing import router as grow_router
 from grow.testing import testing
 
 
-class RoutesTestCase(unittest.TestCase):
+class RouterTestCase(unittest.TestCase):
     """Test the router."""
 
     def setUp(self):
@@ -15,9 +15,13 @@ class RoutesTestCase(unittest.TestCase):
         self.pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
         self.router = grow_router.Router(self.pod)
 
-    def test_router(self):
-        """."""
-        pass
+    def test_filter(self):
+        """Filtering reduces routes."""
+        self.router.add_all()
+        original_len = len(self.router.routes)
+        self.router.filter(locales=['en'])
+        modified_len = len(self.router.routes)
+        self.assertTrue(modified_len < original_len)
 
 
 if __name__ == '__main__':

--- a/grow/routing/routes.py
+++ b/grow/routing/routes.py
@@ -299,10 +299,10 @@ class RouteNode(object):
                 self.path = None
                 self.value = None
 
-        for key in sorted(self._static_children):
+        for key in self._static_children:
             self._static_children[key].filter(func)
 
-        for key in sorted(self._dynamic_children):
+        for key in self._dynamic_children:
             self._dynamic_children[key].filter(func)
 
     def match(self, segments, last_segment=None):

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -174,6 +174,37 @@ class RoutesTestCase(unittest.TestCase):
         actual = list(self.routes.paths)
         self.assertEquals(expected, actual)
 
+    def test_filter(self):
+        """Tests that routes' can be filtered."""
+
+        # Add nodes in random order.
+        self._add('/foo', value=1)
+        self._add('/bax/coo/lib', value=2)
+        self._add('/bax/bar', value=3)
+        self._add('/bax/pan', value=4)
+        self._add('/bax/coo/vin', value=5)
+        self._add('/tem/pon', value=6)
+
+        # Expect the yielded nodes to be in order.
+        expected = [
+            '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
+            '/foo', '/tem/pon',
+        ]
+        actual = list(self.routes.paths)
+        self.assertEquals(expected, actual)
+
+        # Filter specific nodes and test new paths.
+        def _filter_func(value):
+            if value in (2, 5):
+                return False
+            return True
+
+        self.routes.filter(_filter_func)
+
+        expected = ['/bax/bar', '/bax/pan', '/foo', '/tem/pon']
+        actual = list(self.routes.paths)
+        self.assertEquals(expected, actual)
+
     def test_remove(self):
         """Tests that paths can be removed."""
 
@@ -600,6 +631,37 @@ class RoutesSimpleTestCase(unittest.TestCase):
             '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
             '/foo', '/tem/pon',
         ]
+        actual = list(self.routes.paths)
+        self.assertEquals(expected, actual)
+
+    def test_filter(self):
+        """Tests that routes' can be filtered."""
+
+        # Add nodes in random order.
+        self._add('/foo', value=1)
+        self._add('/bax/coo/lib', value=2)
+        self._add('/bax/bar', value=3)
+        self._add('/bax/pan', value=4)
+        self._add('/bax/coo/vin', value=5)
+        self._add('/tem/pon', value=6)
+
+        # Expect the yielded nodes to be in order.
+        expected = [
+            '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
+            '/foo', '/tem/pon',
+        ]
+        actual = list(self.routes.paths)
+        self.assertEquals(expected, actual)
+
+        # Filter specific nodes and test new paths.
+        def _filter_func(value):
+            if value in (2, 5):
+                return False
+            return True
+
+        self.routes.filter(_filter_func)
+
+        expected = ['/bax/bar', '/bax/pan', '/foo', '/tem/pon']
         actual = list(self.routes.paths)
         self.assertEquals(expected, actual)
 

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -187,7 +187,7 @@ class RoutesTestCase(unittest.TestCase):
 
         # Expect the yielded nodes to be in order.
         expected = [
-            '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
+            '/bax/bar', '/bax/coo/lib', '/bax/pan', '/bax/:coo/vin', 
             '/foo', '/tem/pon',
         ]
         actual = list(self.routes.paths)

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -182,7 +182,7 @@ class RoutesTestCase(unittest.TestCase):
         self._add('/bax/coo/lib', value=2)
         self._add('/bax/bar', value=3)
         self._add('/bax/pan', value=4)
-        self._add('/bax/coo/vin', value=5)
+        self._add('/bax/:coo/vin', value=5)
         self._add('/tem/pon', value=6)
 
         # Expect the yielded nodes to be in order.
@@ -191,6 +191,8 @@ class RoutesTestCase(unittest.TestCase):
             '/foo', '/tem/pon',
         ]
         actual = list(self.routes.paths)
+        self.assertEquals(expected, actual)
+        self.routes.filter(None)  # Does nothing.
         self.assertEquals(expected, actual)
 
         # Filter specific nodes and test new paths.


### PR DESCRIPTION
In specific situations you can filter the routes to be built based on locale.

Specifically useful for parallelizing CI builds for large sites based on locales.

ex: `grow build --re-route --locale None --locale en_US`