### PR TITLE
Re-Route: Static Docs and Localization

### DIFF
--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -21,9 +21,12 @@ class StaticDocument(object):
         self.pod_path = pod_path
         self.locale = locale
         self.config = self.pod.router.get_static_config_for_pod_path(pod_path)
-        # When localized the base string should is removed.
+
+        # When localized the base string is changed.
         self.base_source_path = self.config['static_dir']
-        if self.locale is not None and 'localization' in self.config:
+
+        use_locale = locale is not None and locale != pod.podspec.default_locale
+        if use_locale and 'localization' in self.config:
             inherited = {
                 'fingerprinted': self.config.get('fingerprinted', False),
             }
@@ -46,7 +49,7 @@ class StaticDocument(object):
     @property
     def exists(self):
         """Does the static file exist in the pod?"""
-        return self.pod.file_exists(self.pod_path)
+        return self.pod.file_exists(self.source_pod_path)
 
     @property
     def modified(self):
@@ -68,17 +71,26 @@ class StaticDocument(object):
         """Path format for the static document."""
         return '{}{}'.format(
             self.config['serve_at'],
-            self.sub_pod_path)
+            self.sub_base_pod_path)
+
+    @property
+    def source_format(self):
+        """Path format for the source of the document."""
+        return '{}{}'.format(
+            self.source_path,
+            self.sub_base_pod_path)
 
     @property
     def serving_path(self):
         """Serving path for the static document."""
-        return self.pod.path_format.format_static(self)
+        return self.pod.path_format.format_static(
+            self.path_format, locale=self.locale)
 
     @property
     def serving_path_parameterized(self):
         """Parameterized serving path for the static document."""
-        return self.pod.path_format.format_static(self, parameterize=True)
+        return self.pod.path_format.format_static(
+            self.path_format, locale=self.locale, parameterize=True)
 
     @property
     def source_path(self):
@@ -86,9 +98,20 @@ class StaticDocument(object):
         return self.config['static_dir']
 
     @property
-    def sub_pod_path(self):
-        """Unique portion of the static file."""
+    def source_pod_path(self):
+        """Source path for the static document."""
+        return self.pod.path_format.format_static(
+            self.source_format, locale=self.locale)
+
+    @property
+    def sub_base_pod_path(self):
+        """Unique portion of the base static file."""
         return self.pod_path[len(self.base_source_path):]
+
+    @property
+    def sub_pod_path(self):
+        """Unique portion of the full static file."""
+        return self.pod_path[len(self.source_path):]
 
     @property
     def url(self):

--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -25,8 +25,8 @@ class StaticDocument(object):
         # When localized the base string is changed.
         self.base_source_path = self.config['static_dir']
 
-        use_locale = locale is not None and locale != pod.podspec.default_locale
-        if use_locale and 'localization' in self.config:
+        self.use_locale = locale is not None and locale != pod.podspec.default_locale
+        if self.use_locale and 'localization' in self.config:
             inherited = {
                 'fingerprinted': self.config.get('fingerprinted', False),
             }
@@ -99,9 +99,14 @@ class StaticDocument(object):
 
     @property
     def source_pod_path(self):
-        """Source path for the static document."""
-        return self.pod.path_format.format_static(
+        """Source path for the static document with missing file fallback."""
+        source_path = self.pod.path_format.format_static(
             self.source_format, locale=self.locale)
+        # Fall back to the pod path if using locale and the localized
+        # version does not exist.
+        if not self.pod.file_exists(source_path) and self.use_locale:
+            source_path = self.pod_path
+        return source_path
 
     @property
     def sub_base_pod_path(self):

--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -21,6 +21,8 @@ class StaticDocument(object):
         self.pod_path = pod_path
         self.locale = locale
         self.config = self.pod.router.get_static_config_for_pod_path(pod_path)
+        # When localized the base string should is removed.
+        self.base_source_path = self.config['static_dir']
         if self.locale is not None and 'localization' in self.config:
             inherited = {
                 'fingerprinted': self.config.get('fingerprinted', False),
@@ -86,7 +88,7 @@ class StaticDocument(object):
     @property
     def sub_pod_path(self):
         """Unique portion of the static file."""
-        return self.pod_path[len(self.source_path):]
+        return self.pod_path[len(self.base_source_path):]
 
     @property
     def url(self):

--- a/grow/documents/static_document_test.py
+++ b/grow/documents/static_document_test.py
@@ -80,8 +80,8 @@ class StaticDocumentTestCase(unittest.TestCase):
         self.assertEquals('/static/test.txt', static_doc.source_pod_path)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/something.txt', locale='de')
-        self.assertEquals('/static/intl/de/something.txt', static_doc.source_pod_path)
+            self.pod, '/static/test.txt', locale='de')
+        self.assertEquals('/static/intl/de/test.txt', static_doc.source_pod_path)
 
     def test_sub_pod_path(self):
         """Static document source path."""

--- a/grow/documents/static_document_test.py
+++ b/grow/documents/static_document_test.py
@@ -35,7 +35,7 @@ class StaticDocumentTestCase(unittest.TestCase):
         self.assertEquals('/app/static/something.txt', static_doc.path_format)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/intl/{locale}/something.txt', locale='de')
+            self.pod, '/static/something.txt', locale='de')
         self.assertEquals(
             '/app/{root}/static/somepath/{locale}/something.txt', static_doc.path_format)
 
@@ -46,7 +46,7 @@ class StaticDocumentTestCase(unittest.TestCase):
         self.assertEquals('/app/static/test.txt', static_doc.serving_path)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/intl/{locale}/something.txt', locale='de')
+            self.pod, '/static/something.txt', locale='de')
         self.assertEquals(
             '/app/root/static/somepath/de/something.txt', static_doc.serving_path)
 
@@ -58,7 +58,7 @@ class StaticDocumentTestCase(unittest.TestCase):
             '/app/static/test.txt', static_doc.serving_path_parameterized)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/intl/{locale}/something.txt', locale='de')
+            self.pod, '/static/something.txt', locale='de')
         self.assertEquals(
             '/app/root/static/somepath/:locale/something.txt',
             static_doc.serving_path_parameterized)
@@ -70,8 +70,18 @@ class StaticDocumentTestCase(unittest.TestCase):
         self.assertEquals('/static/', static_doc.source_path)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/intl/{locale}/something.txt', locale='de')
+            self.pod, '/static/something.txt', locale='de')
         self.assertEquals('/static/intl/{locale}/', static_doc.source_path)
+
+    def test_source_pod_path(self):
+        """Static document source path."""
+        static_doc = static_document.StaticDocument(
+            self.pod, '/static/test.txt')
+        self.assertEquals('/static/test.txt', static_doc.source_pod_path)
+
+        static_doc = static_document.StaticDocument(
+            self.pod, '/static/something.txt', locale='de')
+        self.assertEquals('/static/intl/de/something.txt', static_doc.source_pod_path)
 
     def test_sub_pod_path(self):
         """Static document source path."""
@@ -94,7 +104,7 @@ class StaticDocumentTestCase(unittest.TestCase):
         self.assertEquals('/app/static/test.txt', static_doc.url.path)
 
         static_doc = static_document.StaticDocument(
-            self.pod, '/static/intl/{locale}/something.txt', locale='de')
+            self.pod, '/static/something.txt', locale='de')
         self.assertEquals(
             '/app/root/static/somepath/de/something.txt', static_doc.url.path)
 

--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -326,6 +326,8 @@ class Document(object):
         if ('$localization' in self.fields
                 and 'path' in self.fields['$localization']):
             return self.fields['$localization']['path']
+        elif '{locale}' in self.fields.get('$path', ''):
+            return self.path_format_base
         elif self.collection.localization:
             return self.collection.localization.get('path')
         return None

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -99,17 +99,14 @@ class PathFormat(object):
 
         return self.strip_double_slash(path)
 
-    def format_static(self, static_doc, parameterize=False):
+    def format_static(self, path, locale=None, parameterize=False):
         """Format a static document url."""
-        path = static_doc.path_format
         path = self.format_pod(path)
 
         if parameterize:
             path = self.parameterize(path)
 
         params = SafeDict()
-
-        params['locale'] = self._locale_or_alias(static_doc.locale)
-
+        params['locale'] = self._locale_or_alias(locale)
         path = self.formatter.vformat(path, (), params)
         return self.strip_double_slash(path)

--- a/grow/routing/path_format_test.py
+++ b/grow/routing/path_format_test.py
@@ -118,9 +118,8 @@ class PathFormatTestCase(unittest.TestCase):
             'root': 'root_path',
         })
         path_format = grow_path_format.PathFormat(pod)
-        doc = _mock_static(pod, '/{root}/test')
         self.assertEquals(
-            '/root_path/test', path_format.format_static(doc))
+            '/root_path/test', path_format.format_static('/{root}/test'))
 
     def test_format_static_locale(self):
         """Test doc paths with locale."""
@@ -128,9 +127,9 @@ class PathFormatTestCase(unittest.TestCase):
             'root': 'root_path',
         })
         path_format = grow_path_format.PathFormat(pod)
-        doc = _mock_static(pod, '/{root}/test/{locale}', locale='es')
         self.assertEquals(
-            '/root_path/test/es', path_format.format_static(doc))
+            '/root_path/test/es', path_format.format_static(
+                '/{root}/test/{locale}', locale='es'))
 
     def test_format_static_locale_params(self):
         """Test doc paths with locale and keeping params."""
@@ -138,10 +137,9 @@ class PathFormatTestCase(unittest.TestCase):
             'root': 'root_path',
         })
         path_format = grow_path_format.PathFormat(pod)
-        doc = _mock_static(pod, '/{root}/test/{locale}', locale='es')
         self.assertEquals(
             '/root_path/test/:locale', path_format.format_static(
-                doc, parameterize=True))
+                '/{root}/test/{locale}', locale='es', parameterize=True))
 
     def test_parameterize(self):
         """Test parameters are converted."""


### PR DESCRIPTION
Fixing up how the static documents are handled when using the `--re-route` flag and internationalized paths.

Fixes #684