### PR TITLE
Adding custom gettext to handle more formatting options.

### DIFF
--- a/grow/common/structures.py
+++ b/grow/common/structures.py
@@ -10,6 +10,13 @@ class AttributeDict(dict):
     __setattr__ = dict.__setitem__
 
 
+class SafeDict(dict):
+    """Keeps the unmatched format params in place."""
+
+    def __missing__(self, key):
+        return '{' + key + '}'
+
+
 class SortedCollection(object):
     """Sequence sorted by a key function.
 

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import string
 import sys
 import threading
 import time
@@ -18,6 +19,7 @@ import bs4
 import html2text
 import translitcodec  # pylint: disable=unused-import
 from collections import OrderedDict
+from grow.common import structures
 from grow.pods import document_fields
 from grow.pods import errors
 
@@ -102,6 +104,13 @@ def interactive_confirm(message, default=False, input_func=None):
     elif choice == 'n':
         return False
     return default
+
+
+FORMATTER = string.Formatter()
+def safe_format(base_string, *args, **kwargs):
+    """Safely format a string using the modern string formatting with fallback."""
+    safe_kwargs = structures.SafeDict(**kwargs)
+    return FORMATTER.vformat(base_string, args, safe_kwargs)
 
 
 def walk(node, callback, parent_key=None, parent_node=None):

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -140,6 +140,17 @@ class UtilsTestCase(unittest.TestCase):
         actual = utils.clean_html(raw)
         self.assertEqual(expected, actual)
 
+    def test_safe_format(self):
+        """Use modern text formatting on a string safely."""
+        actual = utils.safe_format('Does it {0}?', 'work')
+        self.assertEqual('Does it work?', actual)
+
+        actual = utils.safe_format('Does it {work}?', work='blend')
+        self.assertEqual('Does it blend?', actual)
+
+        actual = utils.safe_format('Does it {ignore}?')
+        self.assertEqual('Does it {ignore}?', actual)
+
     def test_validate_name(self):
         with self.assertRaises(errors.BadNameError):
             utils.validate_name('//you/shall/not/pass')

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -34,6 +34,7 @@ from grow.routing import path_format as grow_path_format
 from grow.routing import router as grow_router
 from grow.templates import filters
 from grow.templates import jinja_dependency
+from grow.templates import tags
 from grow.translators import translation_stats
 from grow.translators import translators
 # NOTE: exc imported directly, webob.exc doesn't work when frozen.
@@ -554,12 +555,8 @@ class Pod(object):
             kwargs['extensions'].extend(self.list_jinja_extensions())
             env = jinja_dependency.DepEnvironment(**kwargs)
             env.filters.update(filters.create_builtin_filters())
-            get_gettext_func = self.catalogs.get_gettext_translations
-            # pylint: disable=no-member
-            env.install_gettext_callables(
-                lambda x: get_gettext_func(locale).ugettext(x),
-                lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
-                newstyle=True)
+            env.globals.update(
+                **tags.create_builtin_globals(self, locale=locale))
             return env
 
     def get_routes(self):

--- a/grow/rendering/render_pool.py
+++ b/grow/rendering/render_pool.py
@@ -4,6 +4,7 @@ import random
 import threading
 from grow.templates import filters
 from grow.templates import jinja_dependency
+from grow.templates import tags
 
 
 class Error(Exception):
@@ -76,12 +77,7 @@ class RenderPool(object):
         kwargs['extensions'].extend(self.pod.list_jinja_extensions())
         env = jinja_dependency.DepEnvironment(**kwargs)
         env.filters.update(filters.create_builtin_filters())
-        get_gettext_func = self.pod.catalogs.get_gettext_translations
-        # pylint: disable=no-member
-        env.install_gettext_callables(
-            lambda x: get_gettext_func(locale).ugettext(x),
-            lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
-            newstyle=True)
+        env.globals.update(**tags.create_builtin_globals(self.pod, locale=locale))
         return env
 
     def custom_jinja_env(self, locale='', root=None):

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -6,13 +6,6 @@ import string
 from grow.common import utils
 
 
-class SafeDict(dict):
-    """Keeps the unmatched format params in place."""
-
-    def __missing__(self, key):
-        return '{' + key + '}'
-
-
 class PathFormat(object):
     """Format url paths using the information from the pod."""
 
@@ -50,7 +43,7 @@ class PathFormat(object):
         path = self.format_pod(path)
 
         # Most params should always be replaced.
-        params = SafeDict()
+        params = {}
         params['base'] = doc.base
         params['category'] = doc.category
         params['collection'] = doc.collection
@@ -67,32 +60,32 @@ class PathFormat(object):
                 if isinstance(value, basestring):
                     params['{}|lower'.format(key)] = value.lower()
 
-        path = self.formatter.vformat(path, (), params)
+        path = utils.safe_format(path, (), params)
 
         if parameterize:
             path = self.parameterize(path)
 
-        params = SafeDict()
+        params = {}
 
         if locale is None:
             locale = doc.locale
         params['locale'] = self._locale_or_alias(locale)
 
-        path = self.formatter.vformat(path, (), params)
+        path = utils.safe_format(path, (), params)
         return self.strip_double_slash(path)
 
     def format_pod(self, path, parameterize=False):
         """Format a URL path using the pod information."""
         path = '' if path is None else path
 
-        params = SafeDict()
+        params = {}
         podspec = self.pod.podspec.get_config()
         if 'root' in podspec:
             params['root'] = podspec['root']
         else:
             params['root'] = ''
         params['env'] = self.pod.env
-        path = self.formatter.vformat(path, (), params)
+        path = utils.safe_format(path, (), params)
 
         if parameterize:
             path = self.parameterize(path)
@@ -106,7 +99,7 @@ class PathFormat(object):
         if parameterize:
             path = self.parameterize(path)
 
-        params = SafeDict()
+        params = {}
         params['locale'] = self._locale_or_alias(locale)
-        path = self.formatter.vformat(path, (), params)
+        path = utils.safe_format(path, (), params)
         return self.strip_double_slash(path)

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -60,7 +60,7 @@ class PathFormat(object):
                 if isinstance(value, basestring):
                     params['{}|lower'.format(key)] = value.lower()
 
-        path = utils.safe_format(path, (), params)
+        path = utils.safe_format(path, **params)
 
         if parameterize:
             path = self.parameterize(path)
@@ -71,7 +71,7 @@ class PathFormat(object):
             locale = doc.locale
         params['locale'] = self._locale_or_alias(locale)
 
-        path = utils.safe_format(path, (), params)
+        path = utils.safe_format(path, **params)
         return self.strip_double_slash(path)
 
     def format_pod(self, path, parameterize=False):
@@ -85,7 +85,7 @@ class PathFormat(object):
         else:
             params['root'] = ''
         params['env'] = self.pod.env
-        path = utils.safe_format(path, (), params)
+        path = utils.safe_format(path, **params)
 
         if parameterize:
             path = self.parameterize(path)
@@ -101,5 +101,5 @@ class PathFormat(object):
 
         params = {}
         params['locale'] = self._locale_or_alias(locale)
-        path = utils.safe_format(path, (), params)
+        path = utils.safe_format(path, **params)
         return self.strip_double_slash(path)


### PR DESCRIPTION
Supports using `{name}` in strings to make it easier for translations.

Also supports the normal python new style formatting:

ex: `{name:^10}` pads and centers the value for a 10 width.
ex: `{pi:06.2f}` formats the number -> `003.14`

Keeps the unknown keywords to prevent issues with existing behavior.

ex: `_('{name}: {value}', name='foo')` -> `foo: {value}`

See [pyformat.info](https://pyformat.info/) for more formatting.

Fixes #698 