### PR TITLE
Granular Ignore Filtering for Paths

### DIFF
--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -29,6 +29,7 @@ from grow.preprocessors import preprocessors
 from grow.rendering import rendered_document
 from grow.rendering import renderer
 from grow.rendering import render_pool as grow_render_pool
+from grow.routing import path_filter as grow_path_filter
 from grow.routing import path_format as grow_path_format
 from grow.routing import router as grow_router
 from grow.sdk import updater
@@ -257,6 +258,20 @@ class Pod(object):
     @property
     def logger(self):
         return logger.LOGGER
+
+    @utils.cached_property
+    def path_filter(self):
+        """Filter for testing path formats."""
+        if self.env.name == environment.Name.DEV or self.env.name is None:
+            filter_config = self.yaml.get('filter', {})
+        else:
+            if 'deployments' not in self.yaml:
+                raise ValueError('No pod-specific deployments configured.')
+            filter_config = (self.yaml['deployments']
+                             .get(self.env.name, {})
+                             .get('filter', {}))
+        return grow_path_filter.PathFilter(
+            filter_config.get('ignore_paths'), filter_config.get('include_paths'))
 
     @utils.cached_property
     def path_format(self):

--- a/grow/pods/podspec.py
+++ b/grow/pods/podspec.py
@@ -1,4 +1,5 @@
-# TODO(jeremydw): Implement.
+"""Podspec helper."""
+
 from grow.pods import locales
 
 
@@ -27,8 +28,9 @@ class PodSpec(object):
     def __getattr__(self, name):
         if name in self.fields:
             return self.fields[name]
-        if '{}@'.format(name) in self.fields:
-            return self.fields['{}@'.format(name)]
+        tagged_name = '{}@'.format(name)
+        if tagged_name in self.fields:
+            return self.fields[tagged_name]
         return object.__getattribute__(self, name)
 
     def __iter__(self):

--- a/grow/routing/path_filter.py
+++ b/grow/routing/path_filter.py
@@ -1,0 +1,70 @@
+"""Filter paths to control ignores and includes by path."""
+
+import re
+
+
+DEFAULT_IGNORED = [
+    re.compile(r'^.*/\.[^/]*$'),  # Dot files.
+]
+DEFAULT_INCLUDED = []
+
+
+class PathFilter(object):
+    """Filter for testing paths against a set of filter criteria."""
+
+    def __init__(self, ignored=None, included=None):
+        self._ignored = []
+        self._included = []
+
+        if ignored:
+            for item in ignored:
+                self.add_ignored(item)
+
+        if included:
+            for item in included:
+                self.add_included(item)
+
+    def _is_ignored(self, path):
+        """Test for ignored pattern match."""
+        for pattern in self.ignored:
+            if pattern.search(path):
+                return True
+        return False
+
+    def _is_included(self, path):
+        """Test for include pattern match."""
+        for pattern in self.included:
+            if pattern.search(path):
+                return True
+        return False
+
+    @property
+    def ignored(self):
+        """All ignored patterns."""
+        if not self._ignored and DEFAULT_IGNORED:
+            self._ignored = DEFAULT_IGNORED
+        for item in self._ignored:
+            yield item
+
+    @property
+    def included(self):
+        """All included patterns."""
+        if not self._included and DEFAULT_INCLUDED:
+            self._included = DEFAULT_INCLUDED
+        for item in self._included:
+            yield item
+
+    def add_ignored(self, raw_pattern):
+        """Add a new ignored pattern."""
+        self._ignored.append(re.compile(raw_pattern))
+
+    def add_included(self, raw_pattern):
+        """Add a new included pattern."""
+        self._included.append(re.compile(raw_pattern))
+
+    def is_valid(self, path):
+        """Tests if the path is valid according to the known filters."""
+        if self._is_ignored(path):
+            # Includes override an ignore path.
+            return self._is_included(path)
+        return True

--- a/grow/routing/path_filter.py
+++ b/grow/routing/path_filter.py
@@ -65,6 +65,6 @@ class PathFilter(object):
     def is_valid(self, path):
         """Tests if the path is valid according to the known filters."""
         if self._is_ignored(path):
-            # Includes override an ignore path.
+            # Includes override an ignores.
             return self._is_included(path)
         return True

--- a/grow/routing/path_filter_test.py
+++ b/grow/routing/path_filter_test.py
@@ -1,0 +1,62 @@
+"""Tests for the path filter."""
+
+import unittest
+from grow.routing import path_filter
+
+
+class PathFilterTestCase(unittest.TestCase):
+    """Test the routes."""
+
+    def setUp(self):
+        self.filter = path_filter.PathFilter()
+
+    def test_filter_defaults(self):
+        """Default filters work."""
+        # Normal files work.
+        self.assertTrue(self.filter.is_valid('/sitemap.xml'))
+        self.assertTrue(self.filter.is_valid('/index.html'))
+        self.assertTrue(self.filter.is_valid('/static/images/logo.png'))
+        self.assertTrue(self.filter.is_valid('/.grow/index.html'))
+
+        # Dot files should be ignored.
+        self.assertFalse(self.filter.is_valid('/.DS_STORE'))
+        self.assertFalse(self.filter.is_valid('/.htaccess'))
+
+    def test_filter_ignores(self):
+        """Simple ignore filters work."""
+        self.filter.add_ignored('foo.bar')
+
+        # Normal files work.
+        self.assertTrue(self.filter.is_valid('/sitemap.xml'))
+        self.assertTrue(self.filter.is_valid('/index.html'))
+        self.assertTrue(self.filter.is_valid('/static/images/logo.png'))
+        self.assertTrue(self.filter.is_valid('/.grow/index.html'))
+
+        # Defaults are not kept.
+        self.assertTrue(self.filter.is_valid('/.DS_STORE'))
+        self.assertTrue(self.filter.is_valid('/.htaccess'))
+
+        # Custom filters work.
+        self.assertFalse(self.filter.is_valid('/foo.bar'))
+        self.assertFalse(self.filter.is_valid('/foo/bar/foo.bar'))
+
+    def test_filter_included(self):
+        """Simple included filters work."""
+        self.filter.add_ignored('foo.bar')
+        self.filter.add_included('/bar/foo.bar')
+
+        # Normal files work.
+        self.assertTrue(self.filter.is_valid('/sitemap.xml'))
+        self.assertTrue(self.filter.is_valid('/index.html'))
+        self.assertTrue(self.filter.is_valid('/static/images/logo.png'))
+        self.assertTrue(self.filter.is_valid('/.grow/index.html'))
+
+        # Defaults are not kept.
+        self.assertTrue(self.filter.is_valid('/.DS_STORE'))
+        self.assertTrue(self.filter.is_valid('/.htaccess'))
+
+        # Custom filters work.
+        self.assertFalse(self.filter.is_valid('/foo.bar'))
+
+        # Included filter overrides the ignores.
+        self.assertTrue(self.filter.is_valid('/foo/bar/foo.bar'))

--- a/grow/routing/path_filter_test.py
+++ b/grow/routing/path_filter_test.py
@@ -1,6 +1,7 @@
 """Tests for the path filter."""
 
 import unittest
+import mock
 from grow.routing import path_filter
 
 
@@ -21,6 +22,13 @@ class PathFilterTestCase(unittest.TestCase):
         # Dot files should be ignored.
         self.assertFalse(self.filter.is_valid('/.DS_STORE'))
         self.assertFalse(self.filter.is_valid('/.htaccess'))
+
+    @mock.patch('grow.routing.path_filter.DEFAULT_INCLUDED', [1, 2])
+    @mock.patch('grow.routing.path_filter.DEFAULT_IGNORED', [3, 4])
+    def test_filter_default_filters(self):
+        """Default filters work."""
+        self.assertEqual([1, 2], list(self.filter.included))
+        self.assertEqual([3, 4], list(self.filter.ignored))
 
     def test_filter_ignores(self):
         """Simple ignore filters work."""

--- a/grow/routing/path_filter_test.py
+++ b/grow/routing/path_filter_test.py
@@ -60,3 +60,24 @@ class PathFilterTestCase(unittest.TestCase):
 
         # Included filter overrides the ignores.
         self.assertTrue(self.filter.is_valid('/foo/bar/foo.bar'))
+
+    def test_filter_constructor(self):
+        """Simple ignore filters work."""
+        self.filter = path_filter.PathFilter(
+            ['foo.bar'], ['/bar/foo.bar'])
+
+        # Normal files work.
+        self.assertTrue(self.filter.is_valid('/sitemap.xml'))
+        self.assertTrue(self.filter.is_valid('/index.html'))
+        self.assertTrue(self.filter.is_valid('/static/images/logo.png'))
+        self.assertTrue(self.filter.is_valid('/.grow/index.html'))
+
+        # Defaults are not kept.
+        self.assertTrue(self.filter.is_valid('/.DS_STORE'))
+        self.assertTrue(self.filter.is_valid('/.htaccess'))
+
+        # Custom filters work.
+        self.assertFalse(self.filter.is_valid('/foo.bar'))
+
+        # Included filter overrides the ignores.
+        self.assertTrue(self.filter.is_valid('/foo/bar/foo.bar'))

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -95,8 +95,11 @@ class Router(object):
                 fingerprinted = config.get('fingerprinted', False)
                 localization = config.get('localization')
                 static_filter = config.get('filter', {})
-                path_filter = grow_path_filter.PathFilter(
-                    static_filter.get('ignore_paths'), static_filter.get('include_paths'))
+                if static_filter:
+                    path_filter = grow_path_filter.PathFilter(
+                        static_filter.get('ignore_paths'), static_filter.get('include_paths'))
+                else:
+                    path_filter = self.pod.path_filter
 
                 if concrete or fingerprinted:
                     # Enumerate static files.

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -3,6 +3,7 @@
 import os
 from grow.performance import docs_loader
 from grow.rendering import render_controller
+from grow.routing import path_filter as grow_path_filter
 from grow.routing import routes as grow_routes
 
 
@@ -86,12 +87,16 @@ class Router(object):
     def add_all_static(self, concrete=True):
         """Add all pod docs to the router."""
         with self.pod.profile.timer('Router.add_all_static'):
+            skipped_paths = []
             for config in self.pod.static_configs:
                 if config.get('dev') and not self.pod.env.dev:
                     continue
 
                 fingerprinted = config.get('fingerprinted', False)
                 localization = config.get('localization')
+                static_filter = config.get('filter', {})
+                path_filter = grow_path_filter.PathFilter(
+                    static_filter.get('ignore_paths'), static_filter.get('include_paths'))
 
                 if concrete or fingerprinted:
                     # Enumerate static files.
@@ -104,6 +109,9 @@ class Router(object):
                             pod_path = os.path.join(pod_dir, file_name)
                             static_doc = self.pod.get_static(
                                 pod_path, locale=None)
+                            if not path_filter.is_valid(static_doc.serving_path):
+                                skipped_paths.append(static_doc.serving_path)
+                                continue
                             self.routes.add(
                                 static_doc.serving_path, RouteInfo('static', {
                                     'pod_path': static_doc.pod_path,
@@ -111,6 +119,8 @@ class Router(object):
                                     'localized': False,
                                     'localization': localization,
                                     'fingerprinted': fingerprinted,
+                                    'static_filter': static_filter,
+                                    'path_filter': path_filter,
                                 }))
                 else:
                     serve_at = self.pod.path_format.format_pod(
@@ -121,6 +131,8 @@ class Router(object):
                         'localized': False,
                         'localization': localization,
                         'fingerprinted': fingerprinted,
+                        'static_filter': static_filter,
+                        'path_filter': path_filter,
                     }))
 
                     if localization:
@@ -132,7 +144,12 @@ class Router(object):
                             'localized': True,
                             'localization': localization,
                             'fingerprinted': fingerprinted,
+                            'static_filter': static_filter,
+                            'path_filter': path_filter,
                         }))
+            if skipped_paths:
+                self.pod.logger.info(
+                    'Ignored {} static files.'.format(len(skipped_paths)))
 
     def add_doc(self, doc):
         """Add doc to the router."""
@@ -146,8 +163,12 @@ class Router(object):
     def add_docs(self, docs, concrete=True):
         """Add docs to the router."""
         with self.pod.profile.timer('Router.add_docs'):
+            skipped_paths = []
             for doc in docs:
                 if not doc.has_serving_path():
+                    continue
+                if not self.pod.path_filter.is_valid(doc.get_serving_path()):
+                    skipped_paths.append(doc.get_serving_path())
                     continue
                 if concrete:
                     # Concrete iterates all possible documents.
@@ -175,6 +196,9 @@ class Router(object):
                         self.routes.add(localized_path, RouteInfo('doc', {
                             'pod_path': doc.pod_path,
                         }))
+            if skipped_paths:
+                self.pod.logger.info(
+                    'Ignored {} documents.'.format(len(skipped_paths)))
 
     def add_pod_paths(self, pod_paths, concrete=True):
         """Add pod paths to the router."""
@@ -195,6 +219,7 @@ class Router(object):
             if 'None' in locales:
                 print 'adding None'
                 locales.append(None)
+
             def _filter_locales(route_info):
                 if 'locale' in route_info.meta:
                     return route_info.meta['locale'] in locales


### PR DESCRIPTION
Allows for defining filters for what paths to ignore from builds and deployments.

Used by defining a list of regex expressions that are matched against paths:

```yaml
filter:
  ignore_paths:
  - "\.DS_STORE"
  include_paths:
  - "\.htaccess"
```

There is a default set of ignored paths that ignore all doc files in a directory. By defining a filter it overrides the defaults.

The `include_paths` also overrides the ignore_paths. For example, the ignores could ignore all the files that start with a `.` but then include paths could explicitly define that `.htaccess` files are included.

There are three places that filters can be added:

- Top level of the podspec to control filters for the dev server.
- Deployment config in podspec to control the filters for a specific deployment.
- Static config in podspec to control the filters for a specific static config.