### PR TITLE
Fix new style replace to correctly work with jinja gettext

### DIFF
--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -571,13 +571,8 @@ class Pod(object):
             kwargs['extensions'].extend(self.list_jinja_extensions())
             env = jinja_dependency.DepEnvironment(**kwargs)
             env.filters.update(filters.create_builtin_filters())
-            get_gettext_func = self.catalogs.get_gettext_translations
-            env.install_gettext_callables(
-                lambda x: get_gettext_func(locale).ugettext(x),
-                lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
-                newstyle=True)
-            # env.globals.update(
-            #     **tags.create_builtin_globals(env, self, locale=locale))
+            env.globals.update(
+                **tags.create_builtin_globals(env, self, locale=locale))
             return env
 
     def get_routes(self):

--- a/grow/rendering/render_pool.py
+++ b/grow/rendering/render_pool.py
@@ -77,12 +77,7 @@ class RenderPool(object):
         kwargs['extensions'].extend(self.pod.list_jinja_extensions())
         env = jinja_dependency.DepEnvironment(**kwargs)
         env.filters.update(filters.create_builtin_filters())
-        get_gettext_func = self.pod.catalogs.get_gettext_translations
-        env.install_gettext_callables(
-            lambda x: get_gettext_func(locale).ugettext(x),
-            lambda s, p, n: get_gettext_func(locale).ungettext(s, p, n),
-            newstyle=True)
-        # env.globals.update(**tags.create_builtin_globals(env, self.pod, locale=locale))
+        env.globals.update(**tags.create_builtin_globals(env, self.pod, locale=locale))
         return env
 
     def custom_jinja_env(self, locale='', root=None):

--- a/grow/templates/tags.py
+++ b/grow/templates/tags.py
@@ -176,10 +176,11 @@ def make_gettext(func):
     def gettext(__context, __string, **variables):
         """Gettext and do replacement."""
         value = __context.call(func, __string)
+        value = value % variables
+        value = utils.safe_format(value, **variables)
         if __context.eval_ctx.autoescape:
             value = jinja2.utils.Markup(value)
-        value = value % variables
-        return utils.safe_format(value, **variables)
+        return value
     return gettext
 
 
@@ -190,10 +191,11 @@ def make_ngettext(func):
         """Gettext and do replacement."""
         variables.setdefault('num', __num)
         value = __context.call(func, __singular, __plural, __num)
+        value = value % variables
+        value = utils.safe_format(value, **variables)
         if __context.eval_ctx.autoescape:
             value = jinja2.utils.Markup(value)
-        value = value % variables
-        return utils.safe_format(value, **variables)
+        return value
     return ngettext
 
 

--- a/grow/templates/tags_test.py
+++ b/grow/templates/tags_test.py
@@ -179,71 +179,71 @@ class BuiltinsTestCase(unittest.TestCase):
             '/content/pages/doc3.yaml',
         ], [doc.pod_path for doc in docs])
 
-    # def test_gettext_format(self):
-    #     """Verify that the gettext formatting works."""
-    #     pod = testing.create_pod()
-    #     pod.write_yaml('/podspec.yaml', {
-    #         'localization': {
-    #             'default_locale': 'en',
-    #             'locales': [
-    #                 'en',
-    #                 'es',
-    #             ],
-    #         },
-    #     })
-    #     pod.write_file('/views/format.html', '{{_(doc.foo, bar="1", foo="2")}}')
-    #     fields = {
-    #         'path': '/{locale}/{base}/',
-    #         'localization': {
-    #             'path': '/{locale}/{base}/',
-    #         },
-    #     }
-    #     pod.write_yaml('/content/testing/_blueprint.yaml', fields)
-    #     pod.write_yaml('/content/testing/format.yaml', {
-    #         '$view': '/views/format.html',
-    #         'foo': 'bar {bar} foo {foo}',
-    #         'foo@es': 'foo {foo} bar {bar}',
-    #     })
-    #
-    #     pod.router.add_doc(
-    #         pod.get_doc('/content/testing/format.yaml'))
-    #     pod.router.add_doc(
-    #         pod.get_doc('/content/testing/format.yaml', locale='es'))
-    #
-    #     self.assertIn('bar 1 foo 2', self._render_path(pod, '/en/format/'))
-    #     self.assertIn('foo 2 bar 1', self._render_path(pod, '/es/format/'))
+    def test_gettext_format(self):
+        """Verify that the gettext formatting works."""
+        pod = testing.create_pod()
+        pod.write_yaml('/podspec.yaml', {
+            'localization': {
+                'default_locale': 'en',
+                'locales': [
+                    'en',
+                    'es',
+                ],
+            },
+        })
+        pod.write_file('/views/format.html', '{{_(doc.foo, bar="1", foo="2")}}')
+        fields = {
+            'path': '/{locale}/{base}/',
+            'localization': {
+                'path': '/{locale}/{base}/',
+            },
+        }
+        pod.write_yaml('/content/testing/_blueprint.yaml', fields)
+        pod.write_yaml('/content/testing/format.yaml', {
+            '$view': '/views/format.html',
+            'foo': 'bar {bar} foo {foo}',
+            'foo@es': 'foo {foo} bar {bar}',
+        })
 
-    # def test_gettext_format_entities(self):
-    #     """Verify that the gettext formatting works with entities."""
-    #     pod = testing.create_pod()
-    #     pod.write_yaml('/podspec.yaml', {})
-    #     pod.write_file(
-    #         '/views/format-old.html',
-    #         '{{_(\'Hello %(name)s\', name=\'<strong class="awesome">Alice</strong>\')}}')
-    #     pod.write_file(
-    #         '/views/format-new.html',
-    #         '{{_(\'Hello {name}\', name=\'<strong class="awesome">Alice</strong>\')}}')
-    #     pod.write_yaml('/content/testing/_blueprint.yaml', {
-    #         'path': '/{base}/',
-    #     })
-    #     pod.write_yaml('/content/testing/format-old.yaml', {
-    #         '$view': '/views/format-old.html',
-    #     })
-    #     pod.write_yaml('/content/testing/format-new.yaml', {
-    #         '$view': '/views/format-new.html',
-    #     })
-    #
-    #     pod.router.add_doc(
-    #         pod.get_doc('/content/testing/format-old.yaml'))
-    #     pod.router.add_doc(
-    #         pod.get_doc('/content/testing/format-new.yaml'))
-    #
-    #     self.assertIn(
-    #         'Hello <strong class="awesome">Alice</strong>',
-    #         self._render_path(pod, '/format-old/'))
-    #     self.assertIn(
-    #         'Hello <strong class="awesome">Alice</strong>',
-    #         self._render_path(pod, '/format-new/'))
+        pod.router.add_doc(
+            pod.get_doc('/content/testing/format.yaml'))
+        pod.router.add_doc(
+            pod.get_doc('/content/testing/format.yaml', locale='es'))
+
+        self.assertIn('bar 1 foo 2', self._render_path(pod, '/en/format/'))
+        self.assertIn('foo 2 bar 1', self._render_path(pod, '/es/format/'))
+
+    def test_gettext_format_entities(self):
+        """Verify that the gettext formatting works with entities."""
+        pod = testing.create_pod()
+        pod.write_yaml('/podspec.yaml', {})
+        pod.write_file(
+            '/views/format-old.html',
+            '{{_(\'Hello %(name)s\', name=\'<strong class="awesome">Alice</strong>\')}}')
+        pod.write_file(
+            '/views/format-new.html',
+            '{{_(\'Hello {name}\', name=\'<strong class="awesome">Alice</strong>\')}}')
+        pod.write_yaml('/content/testing/_blueprint.yaml', {
+            'path': '/{base}/',
+        })
+        pod.write_yaml('/content/testing/format-old.yaml', {
+            '$view': '/views/format-old.html',
+        })
+        pod.write_yaml('/content/testing/format-new.yaml', {
+            '$view': '/views/format-new.html',
+        })
+
+        pod.router.add_doc(
+            pod.get_doc('/content/testing/format-old.yaml'))
+        pod.router.add_doc(
+            pod.get_doc('/content/testing/format-new.yaml'))
+
+        self.assertIn(
+            'Hello <strong class="awesome">Alice</strong>',
+            self._render_path(pod, '/format-old/'))
+        self.assertIn(
+            'Hello <strong class="awesome">Alice</strong>',
+            self._render_path(pod, '/format-new/'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixing the value of the replaced string to be marked as safe instead of marking it as safe then doing a replacement.

Fixes #707 