### PR TITLE
Collection Path and Base

### DIFF
--- a/grow/pods/documents.py
+++ b/grow/pods/documents.py
@@ -150,9 +150,12 @@ class Document(object):
         formatters = {
             'base': self.base,
             'category': self.category,
-            'collection.basename': self.collection.basename,
-            'collection.root': self.collection.root,
-            'env.fingerpint': self.pod.env.fingerprint,
+            'collection': structures.AttributeDict(
+                base=self.collection_base,
+                basename=self.collection.basename,
+                root=self.collection.root),
+            'env': structures.AttributeDict(
+                fingerpint=self.pod.env.fingerprint),
             'locale': locale,
             'parent': self.parent if self.parent else utils.DummyDict(),
             'root': podspec.root,
@@ -189,6 +192,16 @@ class Document(object):
     @property
     def category(self):
         return self.fields.get('$category')
+
+    @property
+    def collection_base(self):
+        """The base directory inside the collection."""
+        return self.collection_path[:-len(self.basename)]
+
+    @property
+    def collection_path(self):
+        """The pod path relative to the collection path."""
+        return self.pod_path[len(self.collection.pod_path):]
 
     @property
     def content(self):

--- a/grow/pods/documents_test.py
+++ b/grow/pods/documents_test.py
@@ -96,6 +96,26 @@ class DocumentsTestCase(unittest.TestCase):
         self.assertEquals(expected, documents.Document.clean_localized_path(
             input, 'en'))
 
+    def test_collection_base(self):
+        about_doc = self.pod.get_doc('/content/pages/about.yaml')
+        self.assertEquals('/', about_doc.collection_base)
+
+        about_doc = self.pod.get_doc('/content/pages/sub/about.yaml')
+        self.assertEquals('/sub/', about_doc.collection_base)
+
+        about_doc = self.pod.get_doc('/content/pages/sub/foo/about.yaml')
+        self.assertEquals('/sub/foo/', about_doc.collection_base)
+
+    def test_collection_path(self):
+        about_doc = self.pod.get_doc('/content/pages/about.yaml')
+        self.assertEquals('/about.yaml', about_doc.collection_path)
+
+        about_doc = self.pod.get_doc('/content/pages/sub/about.yaml')
+        self.assertEquals('/sub/about.yaml', about_doc.collection_path)
+
+        about_doc = self.pod.get_doc('/content/pages/sub/foo/about.yaml')
+        self.assertEquals('/sub/foo/about.yaml', about_doc.collection_path)
+
     def test_get_serving_path(self):
         about_doc = self.pod.get_doc('/content/pages/about.yaml')
         self.assertEquals('/about/', about_doc.get_serving_path())


### PR DESCRIPTION
Currently there isn't an easy way to get the path of a document relative to the collection podpath.

Ex: `/content/pages/sub/about.yaml` => `collection_path: /sub/about.yaml`

Also there isn't an easy way to get the base path relative to the collection.

Ex: `/content/pages/sub/about.yaml` => `collection_base: /sub/`

This PR adds both to the document and also adds the collection base to the serving path rendering so you can use something like this to do paths easily for sub pages:

```
# _blueprint.yaml
path: /{collection.base}/{base}/
$localization:
  path: /intl/{locale}/{collection.base}/{base}/
```

Which would translate pages to:

```
/content/pages/about.yaml => /about/
/content/pages/sub/about.yaml => /sub/about/
/content/pages/about.yaml => /intl/es/about/
/content/pages/sub/about.yaml => /intl/es/sub/about/
```