### PR TITLE
Fixing the path formatting to work better with complex formats.

### DIFF
--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -89,11 +89,14 @@ class PathFormat(object):
         """Format a static document url."""
 
         params = self.params_pod()
-        params['locale'] = self._locale_or_alias(locale)
         path = utils.safe_format(path, **params)
 
         if parameterize:
             path = self.parameterize(path)
+
+        params['locale'] = self._locale_or_alias(locale)
+        if params['locale']:
+            path = utils.safe_format(path, **params)
 
         return self.strip_double_slash(path)
 

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -40,10 +40,9 @@ class PathFormat(object):
     def format_doc(self, doc, path, locale=None, parameterize=False):
         """Format a URL path using the doc information."""
         path = '' if path is None else path
-        path = self.format_pod(path)
 
         # Most params should always be replaced.
-        params = {}
+        params = self.params_pod()
         params['base'] = doc.base
         params['category'] = doc.category
         params['collection'] = doc.collection
@@ -78,13 +77,7 @@ class PathFormat(object):
         """Format a URL path using the pod information."""
         path = '' if path is None else path
 
-        params = {}
-        podspec = self.pod.podspec.get_config()
-        if 'root' in podspec:
-            params['root'] = podspec['root']
-        else:
-            params['root'] = ''
-        params['env'] = self.pod.env
+        params = self.params_pod()
         path = utils.safe_format(path, **params)
 
         if parameterize:
@@ -94,12 +87,22 @@ class PathFormat(object):
 
     def format_static(self, path, locale=None, parameterize=False):
         """Format a static document url."""
-        path = self.format_pod(path)
+
+        params = self.params_pod()
+        params['locale'] = self._locale_or_alias(locale)
+        path = utils.safe_format(path, **params)
 
         if parameterize:
             path = self.parameterize(path)
 
-        params = {}
-        params['locale'] = self._locale_or_alias(locale)
-        path = utils.safe_format(path, **params)
         return self.strip_double_slash(path)
+
+    def params_pod(self):
+        params = {}
+        podspec = self.pod.podspec.get_config()
+        if 'root' in podspec:
+            params['root'] = podspec['root']
+        else:
+            params['root'] = ''
+        params['env'] = self.pod.env
+        return params


### PR DESCRIPTION
For example, trying to reference things on the collection object caused issues since the collection object didn't exist when trying to do the `format_pod` inside the `format_doc`.