### PR TITLE
Code Highlighting Improvements

### DIFF
--- a/grow/common/markdown_extensions.py
+++ b/grow/common/markdown_extensions.py
@@ -139,7 +139,6 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
     """
     KIND = 'sourcecode'
     pattern_tag = re.compile(r'\[sourcecode(:.*?)\](.+?)\[/sourcecode\]', re.S)
-    pattern_ticks = re.compile(r'```(.+?)\n(.+?)\n```', re.S)
 
     class Config(messages.Message):
         classes = messages.BooleanField(1, default=False)
@@ -186,7 +185,6 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
             raise ValueError(text.format(self.config.highlighter))
         content = '\n'.join(lines)
         content = self.pattern_tag.sub(repl, content)
-        content = self.pattern_ticks.sub(repl, content)
         return content.split('\n')
 
 

--- a/grow/common/markdown_extensions_test.py
+++ b/grow/common/markdown_extensions_test.py
@@ -248,7 +248,7 @@ class CodeBlockPreprocessorTestCase(unittest.TestCase):
         pod = pods.Pod(pod.root)
         controller, params = pod.match('/test/')
         result = controller.render(params)
-        code_sentinel = '<pre><code class="html">'
+        code_sentinel = '<div class="codehilite"><pre>'
         self.assertIn(code_sentinel, result)
 
 

--- a/grow/documents/document_format.py
+++ b/grow/documents/document_format.py
@@ -140,6 +140,8 @@ class MarkdownDocumentFormat(DocumentFormat):
                 markdown_extensions.CodeBlockExtension(self._doc.pod),
                 markdown_extensions.IncludeExtension(self._doc.pod),
                 markdown_extensions.UrlExtension(self._doc.pod),
+                'markdown.extensions.fenced_code',
+                'markdown.extensions.codehilite',
             ]
             val = markdown.markdown(val.decode('utf-8'), extensions=extensions)
         return val

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.4.0
 GitPython==2.1.7
 GoogleAppEngineCloudStorageClient==1.9.22.1
 Jinja2==2.10
-Markdown==2.6.9
+Markdown==2.6.11
 MarkupSafe==1.0
 PyYAML==3.12
 WebOb==1.7.4


### PR DESCRIPTION
Currently the `[sourcecode]` format for styling source code is a custom extension that is used for providing the syntax highlighting for code using pygments.

The python markdown library has a built-in extensions that support [code blocks](https://python-markdown.github.io/extensions/fenced_code_blocks/) and an extension for [syntax highlighting](https://python-markdown.github.io/extensions/code_hilite/).

This change keeps the existing usage of `[sourcecode]` blocks to use the custom extension, but switches the backtick format to use the built-in extensions for code blocks and formatting.

This also supports the ability to highlight lines:

```md
`​``js hl_lines="1"
console.log('Hello World');
`​``
```

Fixes #730