### PR TITLE
Code Highlight Updates

### DIFF
--- a/grow/common/markdown_extensions.py
+++ b/grow/common/markdown_extensions.py
@@ -190,8 +190,8 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
                     lexer = lexers.TextLexer()
                 return '\n{}\n'.format(highlight(content, lexer, formatter))
             elif self.config.highlighter == 'plain':
-                return '\n\n<pre><code class="%s">%s</code></pre>\n\n' \
-                    % (language, content)
+                return '\n\n<div class="{}"><pre><code class="{}">{}</code></pre></div>\n\n'.format(
+                    self.config.class_name, language, content)
             text = '{} is an invalid highlighter. Valid choices are: pygments, plain.'
             raise ValueError(text.format(self.config.highlighter))
         content = '\n'.join(lines)

--- a/grow/common/markdown_extensions.py
+++ b/grow/common/markdown_extensions.py
@@ -114,7 +114,8 @@ class UrlPreprocessor(preprocessors.Preprocessor):
                         doc = self.pod.get_doc(pod_path)
                     else:
                         doc = self.pod.get_static(pod_path)
-                    line = re.sub(UrlPreprocessor.REGEX, doc.url.path, line, count=1)
+                    line = re.sub(
+                        UrlPreprocessor.REGEX, doc.url.path, line, count=1)
                 new_lines.append(line)
         return new_lines
 
@@ -138,12 +139,15 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
         src/e79a7126551c39d5f8c1b83a79c14e86992155a4/external/markdown-processor.py
     """
     KIND = 'sourcecode'
-    pattern_tag = re.compile(r'\[sourcecode(:.*?)\](.+?)\[/sourcecode\]', re.S)
+    pattern_tag = re.compile(
+        r'\[sourcecode(:(?P<lang>[^, \]]*))?(, hl_lines=(?P<q>[\'"])(?P<lines>[^\'"]*)(?P=q))?\](?P<content>.+?)\[/sourcecode\]',
+        re.S)
 
     class Config(messages.Message):
         classes = messages.BooleanField(1, default=False)
         class_name = messages.StringField(2, default='code')
         highlighter = messages.StringField(3, default='pygments')
+        theme = messages.StringField(4, default='default')
 
     def __init__(self, pod, markdown_instance):
         self.pod = pod
@@ -152,7 +156,7 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
     @property
     @utils.memoize
     def formatter(self):
-        return html.HtmlFormatter(noclasses=(not self.config.classes))
+        return self.get_formatter()
 
     @property
     @utils.memoize
@@ -161,23 +165,30 @@ class CodeBlockPreprocessor(preprocessors.Preprocessor):
             CodeBlockPreprocessor.KIND,
             CodeBlockPreprocessor.Config, self.pod)
 
+    def get_formatter(self, hl_lines=''):
+        return html.HtmlFormatter(
+            noclasses=(not self.config.classes), cssclass=self.config.class_name,
+            style=self.config.theme, hl_lines=hl_lines)
+
     def run(self, lines):
         class_name = self.config.class_name
 
         def repl(m):
-            language = m.group(1)
-            language = language[1:] if language[0] == ':' else language
+            language = m.group('lang')
             if language in ['', 'none']:
                 language = 'text'
-            content = m.group(2)
+            hl_lines = m.group('lines')
+            content = m.group('content')
             if self.config.highlighter == 'pygments':
+                formatter = self.formatter
+                if hl_lines:
+                    formatter = self.get_formatter(hl_lines=hl_lines)
                 try:
                     lexer = lexers.get_lexer_by_name(language)
                 except ValueError:
                     # pylint: disable=no-member
                     lexer = lexers.TextLexer()
-                code = highlight(content, lexer, self.formatter)
-                return '\n\n<div class="%s">%s</div>\n\n' % (class_name, code)
+                return '\n{}\n'.format(highlight(content, lexer, formatter))
             elif self.config.highlighter == 'plain':
                 return '\n\n<pre><code class="%s">%s</code></pre>\n\n' \
                     % (language, content)

--- a/grow/common/markdown_extensions_test.py
+++ b/grow/common/markdown_extensions_test.py
@@ -205,6 +205,42 @@ class CodeBlockPreprocessorTestCase(unittest.TestCase):
         style_sentinel = 'style="background: #f8f8f8"'
         self.assertIn(style_sentinel, result)
 
+        fields = {
+            'markdown': {
+                'extensions': [{
+                    'kind': 'sourcecode',
+                    'highlighter': 'plain',
+                    'classes': True,
+                }],
+            }
+        }
+        pod.write_yaml('/podspec.yaml', fields)
+        pod = pods.Pod(pod.root)
+        controller, params = pod.match('/test/')
+        result = controller.render(params)
+        code_sentinel = '<div class="code"><pre>'
+        self.assertIn(code_sentinel, result)
+
+class BacktickPreprocessorTestCase(unittest.TestCase):
+
+    def test_noclasses(self):
+        pod = testing.create_pod()
+        fields = {
+            'markdown': {
+                'extensions': [{
+                    'kind': 'markdown.extensions.codehilite',
+                }],
+            }
+        }
+        pod.write_yaml('/podspec.yaml', fields)
+        fields = {
+            '$view': '/views/base.html',
+            '$path': '/{base}/'
+        }
+        pod.write_yaml('/content/pages/_blueprint.yaml', fields)
+        content = '{{doc.html|safe}}'
+        pod.write_file('/views/base.html', content)
+
         # Verify ticks.
         content = textwrap.dedent(
             """
@@ -223,7 +259,7 @@ class CodeBlockPreprocessorTestCase(unittest.TestCase):
         fields = {
             'markdown': {
                 'extensions': [{
-                    'kind': 'sourcecode',
+                    'kind': 'markdown.extensions.codehilite',
                     'classes': True,
                 }],
             }
@@ -234,22 +270,6 @@ class CodeBlockPreprocessorTestCase(unittest.TestCase):
         result = controller.render(params)
         class_sentinel = '<span class="nt">'
         self.assertIn(class_sentinel, result)
-
-        fields = {
-            'markdown': {
-                'extensions': [{
-                    'kind': 'sourcecode',
-                    'highlighter': 'plain',
-                    'classes': True,
-                }],
-            }
-        }
-        pod.write_yaml('/podspec.yaml', fields)
-        pod = pods.Pod(pod.root)
-        controller, params = pod.match('/test/')
-        result = controller.render(params)
-        code_sentinel = '<div class="codehilite"><pre>'
-        self.assertIn(code_sentinel, result)
 
 
 if __name__ == '__main__':

--- a/grow/documents/document_format.py
+++ b/grow/documents/document_format.py
@@ -170,8 +170,6 @@ class MarkdownDocumentFormat(DocumentFormat):
             extension_configs = {
                 'markdown.extensions.codehilite': codehilite_config,
             }
-            print 'markdown parse'
-            print extension_configs
             val = markdown.markdown(
                 val.decode('utf-8'), extensions=extensions, extension_configs=extension_configs)
         return val

--- a/grow/documents/document_format.py
+++ b/grow/documents/document_format.py
@@ -3,6 +3,7 @@
 import markdown
 from markdown.extensions import tables
 from grow.common import markdown_extensions
+from grow.common import structures
 from grow.common import utils
 from grow.documents import document_front_matter as doc_front_matter
 
@@ -130,6 +131,17 @@ class HtmlDocumentFormat(DocumentFormat):
 
 class MarkdownDocumentFormat(DocumentFormat):
 
+    def get_markdown_config(self, kind):
+        """Get the markdown config for a specific extension."""
+        if 'markdown' in self._doc.pod.podspec:
+            markdown_config = self._doc.pod.podspec.markdown
+            if 'extensions' in markdown_config:
+                for extension in markdown_config['extensions']:
+                    if extension.get('kind', '') != kind:
+                        continue
+                    return structures.AttributeDict(extension)
+        return structures.AttributeDict({})
+
     @utils.cached_property
     def formatted(self):
         val = self.content
@@ -143,7 +155,23 @@ class MarkdownDocumentFormat(DocumentFormat):
                 'markdown.extensions.fenced_code',
                 'markdown.extensions.codehilite',
             ]
-            val = markdown.markdown(val.decode('utf-8'), extensions=extensions)
+            config = self.get_markdown_config('markdown.extensions.codehilite')
+            codehilite_config = {
+                'pygments_style': 'default',
+                'noclasses': True,
+                'css_class': 'code',
+            }
+            if 'theme' in config:
+                codehilite_config['pygments_style'] = config.theme
+            if 'classes' in config:
+                codehilite_config['noclasses'] = config.classes
+            if 'class_name' in config:
+                codehilite_config['css_class'] = config.class_name
+            extension_configs = {
+                'markdown.extensions.codehilite': codehilite_config,
+            }
+            val = markdown.markdown(
+                val.decode('utf-8'), extensions=extensions, extension_configs=extension_configs)
         return val
 
 

--- a/grow/documents/document_format.py
+++ b/grow/documents/document_format.py
@@ -164,12 +164,14 @@ class MarkdownDocumentFormat(DocumentFormat):
             if 'theme' in config:
                 codehilite_config['pygments_style'] = config.theme
             if 'classes' in config:
-                codehilite_config['noclasses'] = config.classes
+                codehilite_config['noclasses'] = not config.classes
             if 'class_name' in config:
                 codehilite_config['css_class'] = config.class_name
             extension_configs = {
                 'markdown.extensions.codehilite': codehilite_config,
             }
+            print 'markdown parse'
+            print extension_configs
             val = markdown.markdown(
                 val.decode('utf-8'), extensions=extensions, extension_configs=extension_configs)
         return val


### PR DESCRIPTION
Fixing the way that `[sourcecode]` blocks are parsed. Adding support for highlighting lines.

Changed the output from the `[sourcecode]` block to switch from `<div class="code"><div class="highlight">code...</div></div>` to `<div class="code">code...</div>`.

Updated the backtick style formatting to follow the same configuration as the `[sourcecode]`.

Added a `theme` config to switch which styles are used.

Improvements for #730 