### PR TITLE
Adding a deep reference dictionary for referencing delimited dict keys.

### DIFF
--- a/grow/common/structures.py
+++ b/grow/common/structures.py
@@ -10,6 +10,26 @@ class AttributeDict(dict):
     __setattr__ = dict.__setitem__
 
 
+class DeepReferenceDict(dict):
+    """Deep reference dictionary using a delimited key."""
+
+    def __getitem__(self, key):
+        """Handle the ability to do a delimited key."""
+        try:
+            return super(DeepReferenceDict, self).__getitem__(key)
+        except KeyError:
+            data = None
+            for sub_key in key.split('.'):
+                if data is None:
+                    data = self.get(sub_key)
+                    continue
+                if sub_key in data:
+                    data = data[sub_key]
+                else:
+                    raise
+            return data
+
+
 class SafeDict(dict):
     """Keeps the unmatched format params in place."""
 

--- a/grow/common/structures_test.py
+++ b/grow/common/structures_test.py
@@ -17,6 +17,29 @@ class AttributeDictTestCase(unittest.TestCase):
         self.assertEqual('value', obj.key)
 
 
+class DeepReferenceDictTestCase(unittest.TestCase):
+    """Test the deep reference dict structure."""
+
+    def test_deep_reference(self):
+        """Delimited keys are accessible."""
+        obj = structures.DeepReferenceDict({
+            'key': {
+                'sub_key': {
+                    'value': 'foo',
+                }
+            },
+        })
+        self.assertEqual('foo', obj['key']['sub_key']['value'])
+        self.assertEqual('foo', obj['key.sub_key.value'])
+
+    def test_deep_reference_error(self):
+        """Missing keys raise error."""
+        obj = structures.DeepReferenceDict({
+            'key': {},
+        })
+        with self.assertRaises(KeyError):
+            _ = obj['key.sub_key.value']
+
 class SortedCollectionTestCase(unittest.TestCase):
     """Test the sorted collection structure."""
 

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -228,15 +228,6 @@ def make_yaml_loader(pod, doc=None, locale=None):
     class YamlLoader(yaml_Loader):
 
         @staticmethod
-        def deep_reference(reference, data):
-            for key in reference.split('.'):
-                if data and key in data:
-                    data = data[key]
-                else:
-                    return None
-            return data
-
-        @staticmethod
         def read_csv(pod_path):
             """Reads a csv file using a cache."""
             file_cache = pod.podcache.file_cache
@@ -319,8 +310,8 @@ def make_yaml_loader(pod, doc=None, locale=None):
                 if doc:
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
                 if reference:
-                    data = self.read_yaml(path, locale=locale)
-                    return YamlLoader.deep_reference(reference, data)
+                    data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
+                    return data[reference]
                 return None
             return self._construct_func(node, func)
 
@@ -340,8 +331,8 @@ def make_yaml_loader(pod, doc=None, locale=None):
                     path, reference = path.split('?')
                     if doc:
                         pod.podcache.dependency_graph.add(doc.pod_path, path)
-                    data = self.read_yaml(path, locale=locale)
-                    return YamlLoader.deep_reference(reference, data)
+                    data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
+                    return data[reference]
                 if doc:
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
                 return self.read_yaml(path, locale=locale)

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -311,7 +311,10 @@ def make_yaml_loader(pod, doc=None, locale=None):
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
                 if reference:
                     data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
-                    return data[reference]
+                    try:
+                        return data[reference]
+                    except KeyError:
+                        return None
                 return None
             return self._construct_func(node, func)
 
@@ -332,7 +335,10 @@ def make_yaml_loader(pod, doc=None, locale=None):
                     if doc:
                         pod.podcache.dependency_graph.add(doc.pod_path, path)
                     data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
-                    return data[reference]
+                    try:
+                        return data[reference]
+                    except KeyError:
+                        return None
                 if doc:
                     pod.podcache.dependency_graph.add(doc.pod_path, path)
                 return self.read_yaml(path, locale=locale)

--- a/grow/templates/tags.py
+++ b/grow/templates/tags.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import jinja2
 from babel.messages import catalog as babel_catalog
 from grow.collections import collection as collection_lib
+from grow.common import structures
 from grow.common import utils
 from grow.translations import locales as locales_lib
 
@@ -243,6 +244,10 @@ def wrap_locale_context(func):
 def yaml(path, _pod, _doc=None):
     """Retrieves a yaml file from the pod."""
     locale = str(_doc.locale_safe) if _doc else None
+    if '?' in path:
+        path, reference = path.split('?')
+        data = structures.DeepReferenceDict(_read_yaml(_pod, path, locale=locale))
+        return data[reference]
     return _read_yaml(_pod, path, locale=locale)
 
 


### PR DESCRIPTION
Also adds the ability to deep reference yaml in the templates using `{{g.yaml('/content/shared/data.yaml?key.sub_key')}}` syntax.