### PR TITLE
Fixing the path formatting to work correctly with empty paths

### DIFF
--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -35,7 +35,7 @@ class PathFormat(object):
         """Adds trailing slash when appropriate."""
         if not doc.view.endswith(('.html', '.htm')):
             return path
-        if not path.endswith('/'):
+        if path and not path.endswith('/'):
             return '{}/'.format(path)
         return path
 


### PR DESCRIPTION
There was a bug with how paths were formatted when the base path template is empty where it would add a trailing slash.