### PR TITLE
Slug Sequences

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -36,6 +36,7 @@ except ImportError:
 LOCALIZED_KEY_REGEX = re.compile('(.*)@([^@]+)$')
 SENTINEL = object()
 SLUG_REGEX = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
+SLUG_SUBSTITUTE = ((':-', ':'),)
 
 
 class Error(Exception):
@@ -396,7 +397,10 @@ def slugify(text, delim=u'-'):
         word = word.encode('translit/long')
         if word:
             result.append(word)
-    return unicode(delim.join(result))
+    slug = unicode(delim.join(result))
+    for seq, sub in SLUG_SUBSTITUTE:
+        slug = slug.replace(seq, sub)
+    return slug
 
 
 class DummyDict(object):

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -36,7 +36,7 @@ except ImportError:
 LOCALIZED_KEY_REGEX = re.compile('(.*)@([^@]+)$')
 SENTINEL = object()
 SLUG_REGEX = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
-SLUG_SUBSTITUTE = ((':-', ':'),)
+SLUG_SUBSTITUTE = ((':{}', ':'),)
 
 
 class Error(Exception):
@@ -399,7 +399,7 @@ def slugify(text, delim=u'-'):
             result.append(word)
     slug = unicode(delim.join(result))
     for seq, sub in SLUG_SUBSTITUTE:
-        slug = slug.replace(seq, sub)
+        slug = slug.replace(seq.format(delim), sub.format(delim))
     return slug
 
 

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -1,3 +1,4 @@
+# coding: utf8
 """Tests for the common utility methods."""
 
 import unittest
@@ -151,6 +152,17 @@ class UtilsTestCase(unittest.TestCase):
 
         actual = utils.safe_format('Does it {ignore}?')
         self.assertEqual('Does it {ignore}?', actual)
+
+    def test_slugify(self):
+        """Slugify strings."""
+        actual = utils.slugify('What\'s going: down 2 d@y')
+        self.assertEqual('what-s-going:down-2-d-y', actual)
+
+        actual = utils.slugify('Does it {work}')
+        self.assertEqual('does-it-work', actual)
+
+        actual = utils.slugify(u'Îñtérñåtîøñålization')
+        self.assertEqual('internaationaalization', actual)
 
     def test_validate_name(self):
         with self.assertRaises(errors.BadNameError):

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -13,7 +13,8 @@ from grow.common import json_encoder
 from grow.common import urls
 from grow.templates.tags import _gettext_alias
 
-SLUG_REGEX = re.compile(r'[^A-Za-z0-9-._~]+')
+SLUG_REGEX = re.compile(r'[^A-Za-z0-9-._~\:]+')
+SLUG_SEQUENCE = ((u':-', u':'),)
 
 
 def _deep_gettext(ctx, fields):
@@ -115,9 +116,12 @@ def regex_replace():
     return regex_replace_filter
 
 
-def slug_filter(value):
+def slug_filter(value, delimiter=u'-'):
     """Filters string to remove url unfriendly characters."""
-    return unicode(u'-'.join(SLUG_REGEX.split(value.lower())).strip(u'-'))
+    slug = unicode(delimiter.join(SLUG_REGEX.split(value.lower())).strip(delimiter))
+    for seq, sub in SLUG_SEQUENCE:
+        slug = slug.replace(seq, sub)
+    return slug
 
 
 def wrap_locale_context(func):

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -11,10 +11,8 @@ from babel import dates as babel_dates
 from babel import numbers as babel_numbers
 from grow.common import json_encoder
 from grow.common import urls
+from grow.common import utils
 from grow.templates.tags import _gettext_alias
-
-SLUG_REGEX = re.compile(r'[^A-Za-z0-9-._~\:]+')
-SLUG_SEQUENCE = ((u':-', u':'),)
 
 
 def _deep_gettext(ctx, fields):
@@ -118,10 +116,7 @@ def regex_replace():
 
 def slug_filter(value, delimiter=u'-'):
     """Filters string to remove url unfriendly characters."""
-    slug = unicode(delimiter.join(SLUG_REGEX.split(value.lower())).strip(delimiter))
-    for seq, sub in SLUG_SEQUENCE:
-        slug = slug.replace(seq, sub)
-    return slug
+    return utils.slugify(value, delimiter)
 
 
 def wrap_locale_context(func):

--- a/grow/templates/filters_test.py
+++ b/grow/templates/filters_test.py
@@ -24,6 +24,9 @@ class BuiltinsTestCase(unittest.TestCase):
         words = 'Foo\'s b@z b**'
         self.assertEqual('foo-s-b-z-b', filters.slug_filter(words))
 
+        words = 'Foo: b@z b**'
+        self.assertEqual('foo:b-z-b', filters.slug_filter(words))
+
     def test_json(self):
         controller, params = self.pod.match('/json_test/')
         html = controller.render(params)


### PR DESCRIPTION
Standardizing how slugs are created and adding the ability for slug replacement to handle certain sequence replacement. Ex: `:-` => `:`.

Fixes #745