### PR TITLE
Fixing the route loading to better handle localized filenames.

### DIFF
--- a/grow/performance/docs_loader.py
+++ b/grow/performance/docs_loader.py
@@ -61,11 +61,13 @@ class DocsLoader(object):
                     expanded_docs.append(pod.get_doc(doc.pod_path, None))
                     continue
                 for locale in doc.locales:
-                    expanded_docs.append(
-                        pod.get_doc(doc.pod_path, str(locale)))
+                    locale_doc = pod.get_doc(doc.pod_path, str(locale))
+                    if locale_doc.exists:
+                        expanded_docs.append(locale_doc)
                 if doc.default_locale not in locales:
-                    expanded_docs.append(
-                        pod.get_doc(doc.pod_path, doc.default_locale))
+                    locale_doc = pod.get_doc(doc.pod_path, doc.default_locale)
+                    if locale_doc.exists:
+                        expanded_docs.append(locale_doc)
             return expanded_docs
 
     @staticmethod

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -52,10 +52,17 @@ class Router(object):
             docs = []
             for collection in self.pod.list_collections():
                 for doc in collection.list_docs_unread():
+                    is_default_locale = doc._locale_kwarg == self.pod.podspec.default_locale
                     # Ignore localized names in the files since they will be
                     # picked up when the locales are expanded.
-                    if doc.root_pod_path == doc.pod_path:
+                    if doc.root_pod_path == doc.pod_path or is_default_locale:
                         docs.append(doc)
+                    else:
+                        # If this document does not exist with the default
+                        # locale it still needs to be added.
+                        locale_doc = self.pod.get_doc(doc.pod_path, doc.default_locale)
+                        if not locale_doc.exists:
+                            docs.append(doc)
             docs = self._preload_and_expand(docs, expand=concrete)
             self.add_docs(docs, concrete=concrete)
 


### PR DESCRIPTION
When using localized filenames (ex: `content@ru.md` without a default filename (ex: `content.md`) the routes would ignore the localized pod path and not add it to the routes.

Documents that do not have a version with the default locale were also being ignored.

The docs loader also needs to verify that the localized documents exist before adding them to the routes.

Fixes #778