### PR TITLE
Routing Options for Parameters

### DIFF
--- a/grow/rendering/renderer.py
+++ b/grow/rendering/renderer.py
@@ -61,5 +61,5 @@ class Renderer(object):
     @staticmethod
     def controller_generator(pod, routes):
         """Generate the controllers for the given routes."""
-        for path, route_info in routes.nodes:
+        for path, route_info, _ in routes.nodes:
             yield pod.router.get_render_controller(path, route_info)

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -183,7 +183,7 @@ class RoutesTestCase(unittest.TestCase):
             '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
             '/foo', '/tem/pon',
         ]
-        actual = [path for path, _ in self.routes.nodes]
+        actual = [path for path, _, _ in self.routes.nodes]
         self.assertEquals(expected, actual)
 
     def test_paths(self):
@@ -645,7 +645,7 @@ class RoutesSimpleTestCase(unittest.TestCase):
             '/bax/bar', '/bax/coo/lib', '/bax/coo/vin', '/bax/pan',
             '/foo', '/tem/pon',
         ]
-        actual = [path for path, _ in self.routes.nodes]
+        actual = [path for path, _, _ in self.routes.nodes]
         self.assertEquals(expected, actual)
 
     def test_paths(self):

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -7,12 +7,13 @@ from grow.routing import routes as grow_routes
 class RoutesTestCase(unittest.TestCase):
     """Test the routes."""
 
-    def _add(self, path, value=None, custom_routes=None):
+    def _add(self, path, value=None, options=None, custom_routes=None):
         routes = custom_routes if custom_routes is not None else self.routes
-        routes.add(path, value)
+        routes.add(path, value, options=options)
         return {
             'path': path,
             'value': value,
+            'options': options,
         }
 
     def setUp(self):
@@ -27,6 +28,36 @@ class RoutesTestCase(unittest.TestCase):
         doc_foo_bar = self._add('/foo/bar', '/content/pages/foo')
         result = self.routes.match('/foo/bar')
         self.assertEquals(doc_foo_bar['value'], result.value)
+
+    def test_routes_add_params_values(self):
+        """Tests that routes can be added with values for params."""
+        options = {
+            'locale': [
+                'en',
+                'es'
+            ]
+        }
+        doc = self._add('/:locale/', '/content/pages/home', options=options)
+        result = self.routes.match('/en/')
+        self.assertEquals(doc['value'], result.value)
+        result = self.routes.match('/es/')
+        self.assertEquals(doc['value'], result.value)
+        result = self.routes.match('/fr/')
+        self.assertEquals(None, result)
+
+        # Adding another option adds to the set of locale options.
+        options = {
+            'locale': [
+                'fr',
+            ]
+        }
+        doc_new = self._add('/:locale/about', '/content/pages/about', options=options)
+        result = self.routes.match('/es/about')
+        self.assertEquals(doc_new['value'], result.value)
+        result = self.routes.match('/fr/about')
+        self.assertEquals(doc_new['value'], result.value)
+        result = self.routes.match('/de/about')
+        self.assertEquals(None, result)
 
     def test_routes_add_conflict(self):
         """Tests that routes can be added but not conflicting."""
@@ -187,7 +218,7 @@ class RoutesTestCase(unittest.TestCase):
 
         # Expect the yielded nodes to be in order.
         expected = [
-            '/bax/bar', '/bax/coo/lib', '/bax/pan', '/bax/:coo/vin', 
+            '/bax/bar', '/bax/coo/lib', '/bax/pan', '/bax/:coo/vin',
             '/foo', '/tem/pon',
         ]
         actual = list(self.routes.paths)

--- a/grow/ui/admin/partials/routes/routes.html
+++ b/grow/ui/admin/partials/routes/routes.html
@@ -1,7 +1,7 @@
 <div class="routes">
   <h2>Routes</h2>
   <dl class="routes__list">
-    {% for path, info in partial.routes.nodes %}
+    {% for path, info, options in partial.routes.nodes %}
       <dt><a href="{{path}}">{{path}}</a></dt>
       {% if info.kind == 'doc' %}
         <dd>Source: {{info.meta.pod_path}}{% if info.meta.locale %} ({{info.meta.locale}}){% endif %}</dd>
@@ -13,6 +13,9 @@
         <dd>Localization: {{info.meta.localization}}</dd>
       {% else %}
         <dd>{{info}}</dd>
+      {% endif %}
+      {% if options %}
+        <dd>Options: {{options}}</dd>
       {% endif %}
     {% endfor %}
   </dl>


### PR DESCRIPTION
When creating the routing trie allow for specific options to be provided for the parameters.

This allows for the route matching to ignore routes that have a parameter value that does not match and allow it to fall back to a wildcard match.

For example. given the two paths: `/:locale/there` and `/*` and matching `/something/else.js` the locale would always match for `something`, even if `something` is not a valid locale identifier. This enhancement allows for the route matching to correctly determine that `something` is not a valid `locale` option and correctly fallback to a wildcard route.