### PR TITLE
Fix issue where None items inside dependency graph caused log spam.

### DIFF
--- a/grow/extensions/core/routes_extension.py
+++ b/grow/extensions/core/routes_extension.py
@@ -77,6 +77,8 @@ class RoutesDevFileChangeHook(hooks.DevFileChangeHook):
             trigger_docs = col.list_servable_document_locales(pod_path)
 
             for dep_path in pod.podcache.dependency_graph.get_dependents(pod_path):
+                if not dep_path:
+                    continue
                 base_docs.append(pod.get_doc(dep_path))
                 original_docs += col.list_servable_document_locales(dep_path)
 


### PR DESCRIPTION
Not sure if this is the right fix; I think we might want to avoid adding `None` to the dependency graph in the first place.