### PR TITLE
CSV translation file importer

### DIFF
--- a/grow/testing/testdata/external/messages.csv
+++ b/grow/testing/testdata/external/messages.csv
@@ -1,0 +1,3 @@
+en,de
+Hello World,Hallo Welt
+German Translation,Deutsch-Übersetzung

--- a/grow/translations/importers.py
+++ b/grow/translations/importers.py
@@ -65,7 +65,7 @@ class Importer(object):
         elif path.endswith('.csv'):
             return self.import_csv_file(path)
         else:
-            raise Error('Must import a .zip file, .po file, or directory.')
+            raise Error('Must import a .zip, .csv, .po file, or directory.')
 
     def import_csv_file(self, path):
         """Imports a CSV file formatted with locales in the header row and

--- a/grow/translations/importers.py
+++ b/grow/translations/importers.py
@@ -1,14 +1,16 @@
 """Grow translation importers."""
 
-import collections
+from babel.messages import catalog
+from babel.messages import pofile
 import cStringIO
+import collections
 import copy
+import csv
 import errno
 import os
 import shutil
 import tempfile
 import zipfile
-from babel.messages import pofile
 
 
 default_external_to_babel_locales = collections.defaultdict(list)
@@ -60,8 +62,37 @@ class Importer(object):
             return self.import_file(locale, path)
         elif os.path.isdir(path):
             return self.import_dir(path)
+        elif path.endswith('.csv'):
+            return self.import_csv_file(path)
         else:
             raise Error('Must import a .zip file, .po file, or directory.')
+
+    def import_csv_file(self, path):
+        """Imports a CSV file formatted with locales in the header row and
+        translations in the body rows."""
+        default_locale = self.pod.podspec.localization.get('default_locale', 'en')
+        locales_to_catalogs = {}
+        with open(path) as fp:
+            reader = csv.DictReader(fp)
+            for row in reader:
+                if default_locale not in row:
+                    text = 'Locale {} not found in {}'.format(default_locale, path)
+                    raise Error(text)
+                msgid = row[default_locale]
+                for locale, translation in row.iteritems():
+                    if locale == default_locale:
+                        continue
+                    message = catalog.Message(msgid, translation)
+                    if locale not in locales_to_catalogs:
+                        locales_to_catalogs[locale] = catalog.Catalog()
+                    locales_to_catalogs[locale][msgid] = message
+        for locale, catalog_obj in locales_to_catalogs.iteritems():
+            fp = cStringIO.StringIO()
+            pofile.write_po(fp, catalog_obj)
+            fp.seek(0)
+            content = fp.read()
+            self.import_content(locale, content)
+            fp.close()
 
     def import_zip_file(self, zip_path):
         try:

--- a/grow/translations/importers_test.py
+++ b/grow/translations/importers_test.py
@@ -48,6 +48,18 @@ class ImportersTest(unittest.TestCase):
         de_catalog = self.pod.catalogs.get('de')
         self.assertIn('German Translation', de_catalog)
 
+    def test_import_csv(self):
+        de_catalog = self.pod.catalogs.get('de')
+        self.assertNotIn('German Translation', de_catalog)
+        self.assertNotIn('Hello World', de_catalog)
+
+        path = testing.get_testdata_dir()
+        po_path_to_import = os.path.join(path, 'external', 'messages.csv')
+        self.pod.catalogs.import_translations(po_path_to_import)
+        de_catalog = self.pod.catalogs.get('de')
+        self.assertIn('German Translation', de_catalog)
+        self.assertIn('Hello World', de_catalog)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add support for importing CSV translation files, formatted with locales in the header cell and translations in the body.