### PR TITLE
Making sure that the docs only get added once based on the basename.

### DIFF
--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -50,19 +50,24 @@ class Router(object):
         """Add all pod docs to the router."""
         with self.pod.profile.timer('Router.add_all_docs'):
             docs = []
+            doc_basenames = set()
             for collection in self.pod.list_collections():
                 for doc in collection.list_docs_unread():
+                    if doc.basename in doc_basenames:
+                        continue
                     is_default_locale = doc._locale_kwarg == self.pod.podspec.default_locale
                     # Ignore localized names in the files since they will be
                     # picked up when the locales are expanded.
                     if doc.root_pod_path == doc.pod_path or is_default_locale:
                         docs.append(doc)
+                        doc_basenames.add(doc.basename)
                     else:
                         # If this document does not exist with the default
                         # locale it still needs to be added.
                         locale_doc = self.pod.get_doc(doc.pod_path, doc.default_locale)
                         if not locale_doc.exists:
                             docs.append(doc)
+                            doc_basenames.add(doc.basename)
             docs = self._preload_and_expand(docs, expand=concrete)
             self.add_docs(docs, concrete=concrete)
 


### PR DESCRIPTION
When there are localized documents without a default localized file (ex: `file@es.yaml` and `file@fr.yaml` it is possible for the same 'doc' to be added twice to the routes which causes issues with the routing on the dev server. 

This change dedupes the documents based on the `basename` of the doc to keep from adding the same doc multiple times.