### PR TITLE
Locale Alias improvement for routing params

### DIFF
--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -379,7 +379,12 @@ class Document(object):
 
         # When there are locales in a path enumerate the possible locales.
         if '{locale}' in self.path_format_localized:
-            params['locale'] = [str(locale).lower() for locale in self.locales]
+            locale_values = []
+            for locale in self.locales:
+                locale.set_alias(self.pod)
+                locale_values.append(locale.alias)
+                locale_values.append(locale.alias.lower)
+            params['locale'] = locale_values
 
         return params
 

--- a/grow/pods/podspec.py
+++ b/grow/pods/podspec.py
@@ -47,3 +47,13 @@ class PodSpec(object):
     @property
     def localization(self):
         return self.fields.get('localization')
+
+    def get_locale_alias(self, locale):
+        """Get the locale alias for a given locale."""
+        if 'localization' in self.yaml and 'aliases' in self.yaml['localization']:
+            aliases = self.yaml['localization']['aliases']
+            for custom_locale, babel_locale in aliases.iteritems():
+                normalized_babel_locale = babel_locale.lower()
+                if locale == normalized_babel_locale:
+                    return custom_locale
+        return locale

--- a/grow/translations/locales.py
+++ b/grow/translations/locales.py
@@ -104,17 +104,8 @@ class Locale(babel.Locale):
         return cls.parse(alias)
 
     def set_alias(self, pod):
-        normalized_locale = str(self).lower()
         podspec = pod.get_podspec()
-        config = podspec.get_config()
-        if 'localization' in config and 'aliases' in config['localization']:
-            aliases = config['localization']['aliases']
-            for custom_locale, babel_locale in aliases.iteritems():
-                normalized_babel_locale = babel_locale.lower()
-                if normalized_locale == normalized_babel_locale:
-                    normalized_locale = normalized_locale.replace(
-                        normalized_babel_locale, custom_locale)
-        self._alias = normalized_locale
+        self._alias = podspec.get_locale_alias(str(self).lower())
 
     @property
     def alias(self):


### PR DESCRIPTION
Fixing the localization params for routing to not only have the lowercase locales but the unchanged locales as well.

Fixes #787