### PR TITLE
Adjusting the de-duplication to not affect the concrete routing.

### DIFF
--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -53,7 +53,8 @@ class Router(object):
             doc_basenames = set()
             for collection in self.pod.list_collections():
                 for doc in collection.list_docs_unread():
-                    if doc.basename in doc_basenames:
+                    # Skip duplicate documents when using non-concrete routing.
+                    if not concrete and doc.basename in doc_basenames:
                         continue
                     is_default_locale = doc._locale_kwarg == self.pod.podspec.default_locale
                     # Ignore localized names in the files since they will be


### PR DESCRIPTION
The de-duplication that was added in `0.5.3` for local development caused an issue since it was also applying to the concrete routing. This fix make sure that it only affects the non-concrete routes.

Fixes #799 