### PR TITLE
Improve new routing handling of localized paths.

### DIFF
--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -356,7 +356,8 @@ class Document(object):
         elif (self.collection.localization
                 and 'path' in self.collection.localization):
             return self.collection.localization.get('path')
-        elif '{locale}' in self.collection.path_format:
+        elif (self.collection.path_format
+                and '{locale}' in self.collection.path_format):
             return self.collection.path_format
         return None
 

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -386,7 +386,7 @@ class Document(object):
             for locale in self.locales:
                 locale.set_alias(self.pod)
                 locale_values.append(locale.alias)
-                locale_values.append(locale.alias.lower)
+                locale_values.append(locale.alias.lower())
             params['locale'] = locale_values
 
         return params

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -353,8 +353,11 @@ class Document(object):
             return self.fields['$localization']['path']
         elif '{locale}' in self.fields.get('$path', ''):
             return self.path_format_base
-        elif self.collection.localization:
+        elif (self.collection.localization
+                and 'path' in self.collection.localization):
             return self.collection.localization.get('path')
+        elif '{locale}' in self.collection.path_format:
+            return self.collection.path_format
         return None
 
     @property
@@ -575,5 +578,6 @@ class Document(object):
 # Allow the yaml dump to write out a representation of the document.
 def doc_representer(dumper, data):
     return dumper.represent_scalar(u'!g.doc', data.pod_path)
+
 
 yaml.SafeDumper.add_representer(Document, doc_representer)

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -382,11 +382,11 @@ class Document(object):
 
         # When there are locales in a path enumerate the possible locales.
         if '{locale}' in self.path_format_localized:
-            locale_values = []
+            locale_values = set()
             for locale in self.locales:
                 locale.set_alias(self.pod)
-                locale_values.append(locale.alias)
-                locale_values.append(locale.alias.lower())
+                locale_values.add(locale.alias)
+                locale_values.add(locale.alias.lower())
             params['locale'] = locale_values
 
         return params

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -195,7 +195,10 @@ class Router(object):
                 else:
                     # Use the raw paths to parameterize the routing.
                     base_path = doc.get_serving_path_base()
-                    if base_path:
+                    only_localized = doc.path_format == doc.path_format_localized
+                    # If the path is already localized only add the
+                    # parameterized version of the path.
+                    if base_path and not only_localized:
                         self.routes.add(base_path, RouteInfo('doc', {
                             'pod_path': doc.pod_path,
                             'locale': str(doc.locale),


### PR DESCRIPTION
Fixes an issue with the localized path not being picked up when there is no localized path in the document `$path` or `$localization.path` but there is a localized `path` in the collection but no `localization.path` in the collection. :)

Adds a handler to show the abstract path at `/_grow/routes/abstract` in the dev server.

Deduplicates the abstract paths when the localized path format is the same as the default path format.

Deduplicates the locales generated for the path params.