### PR TITLE
Adding custom jinja tests.

### DIFF
--- a/grow/rendering/render_pool.py
+++ b/grow/rendering/render_pool.py
@@ -5,6 +5,7 @@ import threading
 from grow.templates import filters
 from grow.templates import jinja_dependency
 from grow.templates import tags
+from grow.templates import tests as jinja_tests
 
 
 class Error(Exception):
@@ -78,6 +79,7 @@ class RenderPool(object):
         env = jinja_dependency.DepEnvironment(**kwargs)
         env.filters.update(filters.create_builtin_filters())
         env.globals.update(**tags.create_builtin_globals(env, self.pod, locale=locale))
+        env.tests.update(jinja_tests.create_builtin_tests())
         return env
 
     def custom_jinja_env(self, locale='', root=None):

--- a/grow/templates/tests.py
+++ b/grow/templates/tests.py
@@ -1,16 +1,16 @@
 """Template jinja tests."""
 
-def test_subset_of(value, subset):
+def is_subset_of(value, subset):
     """Check if a variable is a subset."""
     return set(value) >= set(subset)
 
-def test_superset_of(value, superset):
-    """Check if a variable is a subset."""
+def is_superset_of(value, superset):
+    """Check if a variable is a superset."""
     return set(value) <= set(superset)
 
 def create_builtin_tests():
     """Tests standard for the template rendering."""
     return (
-        ('subset', test_subset_of),
-        ('superset', test_superset_of),
+        ('subset', is_subset_of),
+        ('superset', is_superset_of),
     )

--- a/grow/templates/tests.py
+++ b/grow/templates/tests.py
@@ -1,0 +1,16 @@
+"""Template jinja tests."""
+
+def test_subset_of(value, subset):
+    """Check if a variable is a subset."""
+    return set(value) >= set(subset)
+
+def test_superset_of(value, superset):
+    """Check if a variable is a subset."""
+    return set(value) <= set(superset)
+
+def create_builtin_tests():
+    """Tests standard for the template rendering."""
+    return (
+        ('subset', test_subset_of),
+        ('superset', test_superset_of),
+    )

--- a/grow/templates/tests_test.py
+++ b/grow/templates/tests_test.py
@@ -10,49 +10,49 @@ class BuiltinTestsTestCase(unittest.TestCase):
         """Provided value is a subset when has all the required values."""
         value = ['banana', 'apple']
         test_value = ['banana']
-        self.assertTrue(tests.test_subset_of(value, test_value))
+        self.assertTrue(tests.is_subset_of(value, test_value))
 
     def test_subset_filter_equal(self):
         """Provided value is a subset when equal."""
         value = ['banana']
         test_value = ['banana']
-        self.assertTrue(tests.test_subset_of(value, test_value))
+        self.assertTrue(tests.is_subset_of(value, test_value))
 
     def test_subset_filter_not(self):
         """Provided value is not a subset when missing values."""
         value = ['banana']
         test_value = ['banana', 'apple']
-        self.assertFalse(tests.test_subset_of(value, test_value))
+        self.assertFalse(tests.is_subset_of(value, test_value))
 
     def test_subset_filter_none(self):
         """Provided value is a subset when both are blank."""
         value = []
         test_value = []
-        self.assertTrue(tests.test_subset_of(value, test_value))
+        self.assertTrue(tests.is_subset_of(value, test_value))
 
     def test_superset_filter(self):
         """Provided value is a superset when missing some of the values."""
         value = ['banana']
         test_value = ['banana', 'apple']
-        self.assertTrue(tests.test_superset_of(value, test_value))
+        self.assertTrue(tests.is_superset_of(value, test_value))
 
     def test_superset_filter_equal(self):
         """Provided value is a superset when equal."""
         value = ['banana']
         test_value = ['banana']
-        self.assertTrue(tests.test_superset_of(value, test_value))
+        self.assertTrue(tests.is_superset_of(value, test_value))
 
     def test_superset_filter_not(self):
         """Provided value is not a superset when has extra values."""
         value = ['banana', 'apple']
         test_value = ['banana']
-        self.assertFalse(tests.test_superset_of(value, test_value))
+        self.assertFalse(tests.is_superset_of(value, test_value))
 
     def test_superset_filter_none(self):
         """Provided value is a superset when both are blank."""
         value = []
         test_value = []
-        self.assertTrue(tests.test_superset_of(value, test_value))
+        self.assertTrue(tests.is_superset_of(value, test_value))
 
 
 if __name__ == '__main__':

--- a/grow/templates/tests_test.py
+++ b/grow/templates/tests_test.py
@@ -1,0 +1,59 @@
+"""Tests for the template tests."""
+
+import unittest
+from grow.templates import tests
+
+
+class BuiltinTestsTestCase(unittest.TestCase):
+
+    def test_subset_filter(self):
+        """Provided value is a subset when has all the required values."""
+        value = ['banana', 'apple']
+        test_value = ['banana']
+        self.assertTrue(tests.test_subset_of(value, test_value))
+
+    def test_subset_filter_equal(self):
+        """Provided value is a subset when equal."""
+        value = ['banana']
+        test_value = ['banana']
+        self.assertTrue(tests.test_subset_of(value, test_value))
+
+    def test_subset_filter_not(self):
+        """Provided value is not a subset when missing values."""
+        value = ['banana']
+        test_value = ['banana', 'apple']
+        self.assertFalse(tests.test_subset_of(value, test_value))
+
+    def test_subset_filter_none(self):
+        """Provided value is a subset when both are blank."""
+        value = []
+        test_value = []
+        self.assertTrue(tests.test_subset_of(value, test_value))
+
+    def test_superset_filter(self):
+        """Provided value is a superset when missing some of the values."""
+        value = ['banana']
+        test_value = ['banana', 'apple']
+        self.assertTrue(tests.test_superset_of(value, test_value))
+
+    def test_superset_filter_equal(self):
+        """Provided value is a superset when equal."""
+        value = ['banana']
+        test_value = ['banana']
+        self.assertTrue(tests.test_superset_of(value, test_value))
+
+    def test_superset_filter_not(self):
+        """Provided value is not a superset when has extra values."""
+        value = ['banana', 'apple']
+        test_value = ['banana']
+        self.assertFalse(tests.test_superset_of(value, test_value))
+
+    def test_superset_filter_none(self):
+        """Provided value is a superset when both are blank."""
+        value = []
+        test_value = []
+        self.assertTrue(tests.test_superset_of(value, test_value))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allows for the ability to define non-default Jinja tests. See [built-in tests](http://jinja.pocoo.org/docs/2.10/templates/#list-of-builtin-tests) for examples.

Adds the `subset` and `superset` which allow for comparing two lists against each other.