### PR TITLE
Reverting the non-replacing part of the extraction marked strings.

### DIFF
--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -62,8 +62,6 @@ class Untag(object):
 
             # Support <key>@<locale regex>: <value>.
             match = LOCALIZED_KEY_REGEX.match(key)
-            if match:
-                print match.groups()
             if not match:
                 if (path, key) in untagged_key_paths:
                     return False

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -4,7 +4,7 @@ import re
 from boltons import iterutils
 
 
-LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)[@]?$')
+LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)$')
 
 
 class Untag(object):

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -77,7 +77,7 @@ class Untag(object):
                 return False
 
             # TODO: Once the translation process is able to correctly extract
-            # the locale tagged extractions we need to keep replacing the value.
+            # the locale tagged extractions we need to prevent replacing.
             # # When marked for extraction when tagged it should be used as the
             # # translation value in the message catalog, not replace the value.
             # if marked_for_extraction:

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -4,7 +4,7 @@ import re
 from boltons import iterutils
 
 
-LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)$')
+LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)[@]?$')
 
 
 class Untag(object):
@@ -62,18 +62,27 @@ class Untag(object):
 
             # Support <key>@<locale regex>: <value>.
             match = LOCALIZED_KEY_REGEX.match(key)
+            if match:
+                print match.groups()
             if not match:
                 if (path, key) in untagged_key_paths:
                     return False
                 return key, value
             untagged_key, locale_from_key = match.groups()
 
+            if not locale_identifier:
+                return False
+
             # If the key has already been untagged, don't overwrite.
             if (path, untagged_key) in untagged_key_paths:
                 return False
 
-            if marked_for_extraction or not locale_identifier:
-                return False
+            # TODO: Once the translation process is able to correctly extract
+            # the locale tagged extractions we need to keep replacing the value.
+            # # When marked for extraction when tagged it should be used as the
+            # # translation value in the message catalog, not replace the value.
+            # if marked_for_extraction:
+            #     return False
 
             locale_regex = re.compile(
                 r'^{}$'.format(locale_from_key), re.IGNORECASE)

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -66,10 +66,11 @@ class Untag(object):
                 if (path, key) in untagged_key_paths:
                     return False
                 return key, value
-            untagged_key, locale_from_key = match.groups()
 
             if not locale_identifier:
                 return False
+
+            untagged_key, locale_from_key = match.groups()
 
             # If the key has already been untagged, don't overwrite.
             if (path, untagged_key) in untagged_key_paths:

--- a/grow/common/untag_test.py
+++ b/grow/common/untag_test.py
@@ -627,7 +627,7 @@ class UntagTestCase(unittest.TestCase):
         }))
 
     # TODO: Once the translation process is able to correctly extract
-    # the locale tagged extractions we need to keep replacing the value.
+    # the locale tagged extractions we need to prevent replacing the value.
     # def test_untag_translation(self):
     #     """Untag when tagged for translation.
     #

--- a/grow/common/untag_test.py
+++ b/grow/common/untag_test.py
@@ -626,29 +626,31 @@ class UntagTestCase(unittest.TestCase):
             'env': untag.UntagParamRegex('prod'),
         }))
 
-    def test_untag_translation(self):
-        """Untag when tagged for translation.
-
-        When untagging a locale that has a trailing @ it is used as the
-        translated value for the key, not as the actual value untagged.
-
-        This makes it so that translated values are done as translations so
-        gettext works correctly in templates.
-
-        See https://docs.google.com/document/d/19rFeAdIjO6mHJG8p8MuOHy5ywG4bYD3FlLdH81dH5Og/
-        """
-        untag_func = untag.Untag.untag
-        fields_to_test = {
-            'foo@': 'base',
-            'foo@fr@': 'fr',
-        }
-        fields = copy.deepcopy(fields_to_test)
-        self.assertDictEqual({
-            'foo': 'base',
-        }, untag_func(fields, locale_identifier=None))
-        self.assertDictEqual({
-            'foo': 'base',
-        }, untag_func(fields, locale_identifier='fr'))
+    # TODO: Once the translation process is able to correctly extract
+    # the locale tagged extractions we need to keep replacing the value.
+    # def test_untag_translation(self):
+    #     """Untag when tagged for translation.
+    #
+    #     When untagging a locale that has a trailing @ it is used as the
+    #     translated value for the key, not as the actual value untagged.
+    #
+    #     This makes it so that translated values are done as translations so
+    #     gettext works correctly in templates.
+    #
+    #     See https://docs.google.com/document/d/19rFeAdIjO6mHJG8p8MuOHy5ywG4bYD3FlLdH81dH5Og/
+    #     """
+    #     untag_func = untag.Untag.untag
+    #     fields_to_test = {
+    #         'foo@': 'base',
+    #         'foo@fr@': 'fr',
+    #     }
+    #     fields = copy.deepcopy(fields_to_test)
+    #     self.assertDictEqual({
+    #         'foo': 'base',
+    #     }, untag_func(fields, locale_identifier=None))
+    #     self.assertDictEqual({
+    #         'foo': 'base',
+    #     }, untag_func(fields, locale_identifier='fr'))
 
     def test_untag_translation_comment(self):
         """Untag ignored translation comments."""


### PR DESCRIPTION
This feature is only half completed since the behavior described in the [design doc](https://docs.google.com/document/d/19rFeAdIjO6mHJG8p8MuOHy5ywG4bYD3FlLdH81dH5Og) does not have the extraction support to correctly update the message catalogs with the value that is tagged for extraction.