### PR TITLE
Experiments in Grow

### DIFF
--- a/grow/common/features.py
+++ b/grow/common/features.py
@@ -31,7 +31,8 @@ class Features(object):
         """Enable the feature."""
         self._enabled.add(feature)
         self._disabled.discard(feature)
-        self._config[feature] = base_config.BaseConfig(config=config or {})
+        if config:
+            self._config[feature] = base_config.BaseConfig(config=config)
 
     def is_disabled(self, feature):
         """Determine if the feature is disabled."""

--- a/grow/common/features.py
+++ b/grow/common/features.py
@@ -6,6 +6,7 @@ class Features(object):
     def __init__(self, enabled=None, disabled=None, default_enabled=True):
         self._enabled = set()
         self._disabled = set()
+        self._config = {}
         self.default_enabled = default_enabled
 
         if enabled is not None:
@@ -16,14 +17,19 @@ class Features(object):
             for feature in disabled:
                 self.disable(feature)
 
+    def config(self, feature):
+        """Configuration for a feature."""
+        return self._config.get(feature, {})
+
     def disable(self, feature):
         """Disable the feature."""
         self._disabled.add(feature)
 
-    def enable(self, feature):
+    def enable(self, feature, config=None):
         """Enable the feature."""
         self._enabled.add(feature)
         self._disabled.discard(feature)
+        self._config[feature] = config or {}
 
     def is_disabled(self, feature):
         """Determine if the feature is disabled."""

--- a/grow/common/features.py
+++ b/grow/common/features.py
@@ -1,5 +1,7 @@
 """Features control."""
 
+from grow.common import base_config
+
 class Features(object):
     """Control features."""
 
@@ -19,7 +21,7 @@ class Features(object):
 
     def config(self, feature):
         """Configuration for a feature."""
-        return self._config.get(feature, {})
+        return self._config.get(feature, base_config.BaseConfig())
 
     def disable(self, feature):
         """Disable the feature."""
@@ -29,7 +31,7 @@ class Features(object):
         """Enable the feature."""
         self._enabled.add(feature)
         self._disabled.discard(feature)
-        self._config[feature] = config or {}
+        self._config[feature] = base_config.BaseConfig(config=config or {})
 
     def is_disabled(self, feature):
         """Determine if the feature is disabled."""

--- a/grow/common/features_test.py
+++ b/grow/common/features_test.py
@@ -37,7 +37,7 @@ class FeaturesTestCase(unittest.TestCase):
         self.assertFalse(feat.is_enabled('a'))
         feat.enable('a', {'config': True})
         self.assertTrue(feat.is_enabled('a'))
-        self.assertEqual({'config': True}, feat.config('a'))
+        self.assertEqual({'config': True}, feat.config('a').export())
 
     def test_enable_without_config(self):
         """Enabling feature without a config."""
@@ -45,7 +45,7 @@ class FeaturesTestCase(unittest.TestCase):
         self.assertFalse(feat.is_enabled('a'))
         feat.enable('a')
         self.assertTrue(feat.is_enabled('a'))
-        self.assertEqual({}, feat.config('a'))
+        self.assertEqual({}, feat.config('a').export())
 
     def test_is_disabled_disabled(self):
         """Enabled features."""

--- a/grow/common/features_test.py
+++ b/grow/common/features_test.py
@@ -17,6 +17,36 @@ class FeaturesTestCase(unittest.TestCase):
         feat = features.Features(default_enabled=False)
         self.assertFalse(feat.is_enabled('unknown'))
 
+    def test_disable(self):
+        """Disabling feature."""
+        feat = features.Features(default_enabled=True)
+        self.assertTrue(feat.is_enabled('a'))
+        feat.disable('a')
+        self.assertFalse(feat.is_enabled('a'))
+
+    def test_enable(self):
+        """Enabling feature."""
+        feat = features.Features(default_enabled=False)
+        self.assertFalse(feat.is_enabled('a'))
+        feat.enable('a')
+        self.assertTrue(feat.is_enabled('a'))
+
+    def test_enable_with_config(self):
+        """Enabling feature with a config."""
+        feat = features.Features(default_enabled=False)
+        self.assertFalse(feat.is_enabled('a'))
+        feat.enable('a', {'config': True})
+        self.assertTrue(feat.is_enabled('a'))
+        self.assertEqual({'config': True}, feat.config('a'))
+
+    def test_enable_without_config(self):
+        """Enabling feature without a config."""
+        feat = features.Features(default_enabled=False)
+        self.assertFalse(feat.is_enabled('a'))
+        feat.enable('a')
+        self.assertTrue(feat.is_enabled('a'))
+        self.assertEqual({}, feat.config('a'))
+
     def test_is_disabled_disabled(self):
         """Enabled features."""
         feat = features.Features(disabled=['a', 'b'])

--- a/grow/pods/pods_test.py
+++ b/grow/pods/pods_test.py
@@ -27,6 +27,17 @@ class PodTest(unittest.TestCase):
         self.pod.enable(self.pod.FEATURE_TRANSLATION_STATS)
         self.assertTrue(self.pod.is_enabled(self.pod.FEATURE_TRANSLATION_STATS))
 
+    def test_experiment_no_config(self):
+        """Experiments with true value are enabled with no config."""
+        self.assertTrue(self.pod.experiments.is_enabled('test_a'))
+        self.assertEqual({}, self.pod.experiments.config('test_a').export())
+
+    def test_experiment_config(self):
+        """Experiments with configs are enabled with config."""
+        self.assertTrue(self.pod.experiments.is_enabled('test_b'))
+        self.assertEqual(
+            {'value': 'foo'}, self.pod.experiments.config('test_b').export())
+
     def test_eq(self):
         pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
         self.assertEqual(self.pod, pod)

--- a/grow/testing/testdata/pod/podspec.yaml
+++ b/grow/testing/testdata/pod/podspec.yaml
@@ -90,3 +90,8 @@ extensions:
   - extensions.preprocessors.CustomPreprocessor
   translators:
   - extensions.translators.CustomTranslator
+
+experiments:
+  test_a: True
+  test_b:
+    value: foo


### PR DESCRIPTION
Adds ability for enabling experiments using the podspec configuration. This will allow for future grow features that are based on experiments without affecting normal grow users.

Fixes #879 