### PR TITLE
Reworking when errors are thrown for missing docs.

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -297,6 +297,9 @@ def make_yaml_loader(pod, doc=None, locale=None, untag_params=None):
 
             def func(path):
                 contructed_doc = pod.get_doc(path, locale=locale)
+                if not contructed_doc.exists:
+                    raise errors.DocumentDoesNotExistError(
+                        'Referenced document does not exist: {}'.format(path))
                 pod.podcache.dependency_graph.add(
                     pod_path, contructed_doc.pod_path)
                 return contructed_doc

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -41,11 +41,6 @@ class Error(Exception):
     pass
 
 
-class DocumentDoesNotExistError(Error, ValueError):
-    """Document path does not exist as a document."""
-    pass
-
-
 class DocumentExistsError(Error, ValueError):
     pass
 
@@ -426,6 +421,8 @@ class Document(object):
 
     @utils.memoize
     def get_serving_path(self):
+        #
+
         # Get root path.
         path_format = self.path_format
         if path_format is None:

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -421,8 +421,6 @@ class Document(object):
 
     @utils.memoize
     def get_serving_path(self):
-        #
-
         # Get root path.
         path_format = self.path_format
         if path_format is None:

--- a/grow/documents/document_test.py
+++ b/grow/documents/document_test.py
@@ -244,8 +244,8 @@ class DocumentsTestCase(unittest.TestCase):
         self.assertTrue(doc.exists)
         doc = self.pod.get_doc('/content/localized/localized.yaml', locale='de')
         self.assertTrue(doc.exists)
-        with self.assertRaises(document.DocumentDoesNotExistError):
-            self.pod.get_doc('/content/localized/does-not-exist.yaml')
+        doc = self.pod.get_doc('/content/localized/does-not-exist.yaml')
+        self.assertFalse(doc.exists)
 
     def test_multi_file_localization(self):
         fr_doc = self.pod.get_doc('/content/pages/intro.md', locale='fr')

--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -11,11 +11,6 @@ class Error(Exception):
     pass
 
 
-class DocumentDoesNotExistError(Error, ValueError):
-    """Static document does not exist."""
-    pass
-
-
 class StaticDocument(object):
     """Static document."""
 

--- a/grow/pods/errors.py
+++ b/grow/pods/errors.py
@@ -2,6 +2,11 @@ class Error(Exception):
     """Base Exception class for module."""
 
 
+class DocumentDoesNotExistError(Error, ValueError):
+    """Document path does not exist as a document."""
+    pass
+
+
 class RouteNotFoundError(Error, KeyError):
     """Raised when a resource is not found within the pod."""
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -543,9 +543,6 @@ class Pod(object):
                 col = self.get_collection(original_collection_path)
                 break
         doc = col.get_doc(pod_path, locale=locale)
-        if not doc.exists:
-            raise document.DocumentDoesNotExistError(
-                'Referenced document does not exist: {}'.format(pod_path))
         return doc
 
     def get_home_doc(self):
@@ -589,7 +586,7 @@ class Pod(object):
         text = ('Either no file exists at "{}" or the "static_dirs" setting was '
                 'not configured for this path in {}.'.format(
                     pod_path, self.FILE_PODSPEC))
-        raise static_document.DocumentDoesNotExistError(text)
+        raise errors.DocumentDoesNotExistError(text)
 
     def get_podspec(self):
         return self.podspec
@@ -639,7 +636,7 @@ class Pod(object):
             doc = self.get_static(pod_path, locale=locale)
 
         if not doc.exists:
-            raise document.DocumentDoesNotExistError(
+            raise errors.DocumentDoesNotExistError(
                 'Referenced document does not exist: {}'.format(pod_path))
         return doc.url
 


### PR DESCRIPTION
Referencing docs no longer throws and error, but if you try to access the URL or use them in yaml then it will throw an exception.

Fixes #884