### PR TITLE
Experiment: Collection Routing

### DIFF
--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -6,6 +6,7 @@ import operator
 import os
 import re
 import sys
+from grow.collections import collection_routes
 from grow.common import structures
 from grow.common import untag
 from grow.common import utils
@@ -209,6 +210,11 @@ class Collection(object):
     @property
     def root(self):
         return self._get_builtin_field('root')
+
+    @utils.cached_property
+    def routes(self):
+        return collection_routes.CollectionRoutes(
+            self.pod, self.pod_path)
 
     @property
     def tagged_fields(self):

--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -7,11 +7,11 @@ import os
 import re
 import sys
 from grow.collections import collection_routes
+from grow.common import features
 from grow.common import structures
 from grow.common import untag
 from grow.common import utils
 from grow.documents import document
-from grow.documents import document_fields
 from grow.documents import document_front_matter
 from grow.translations import locales
 from grow.pods import messages
@@ -49,6 +49,7 @@ class Collection(object):
     CONTENT_PATH = '/content'
     BLUEPRINT_PATH = '_blueprint.yaml'
     EDITOR_PATH = '_editor.yaml'
+    FEATURE_SEPARATE_ROUTING = 'separate_routing'
     IGNORE_INITIAL = ('_',)
 
     _content_path_regex = re.compile('^' + CONTENT_PATH + '/?')
@@ -166,6 +167,19 @@ class Collection(object):
         return self.pod.file_exists(self.blueprint_path)
 
     @utils.cached_property
+    def features(self):
+        """Collection features."""
+        coll_features = features.Features(disabled=[
+            self.FEATURE_SEPARATE_ROUTING,
+        ])
+
+        # Enable the separate_routing feature if there are routes specified.
+        if self.yaml.get('routes', {}):
+            coll_features.enable(self.FEATURE_SEPARATE_ROUTING)
+
+        return coll_features
+
+    @utils.cached_property
     def fields(self):
         fields = untag.Untag.untag(
             self.tagged_fields, params={
@@ -213,8 +227,7 @@ class Collection(object):
 
     @utils.cached_property
     def routes(self):
-        return collection_routes.CollectionRoutes(
-            self.pod, self.pod_path)
+        return collection_routes.CollectionRoutes(self.fields.get('routes', {}))
 
     @property
     def tagged_fields(self):

--- a/grow/collections/collection_routes.py
+++ b/grow/collections/collection_routes.py
@@ -1,8 +1,6 @@
 """Routing information for the collection."""
 
 import os
-import yaml
-from grow.common import untag
 
 
 class CollectionRoutes(object):
@@ -15,28 +13,12 @@ class CollectionRoutes(object):
             return self.get_field(pod_path, attr, default_value)
         return _get_field
 
-    def __init__(self, pod, collection_path):
-        self.pod = pod
-        self.collection_path = collection_path
-        self.routes_path = os.path.join(collection_path, self.ROUTES_PATH)
-        self.pod_paths = {}
-        self._read_routes()
+    def __init__(self, pod_paths=None):
+        self.pod_paths = pod_paths or {}
 
     def _get_meta(self, pod_path):
+        pod_path = pod_path.lstrip(os.path.sep)
         return self.pod_paths.get(pod_path, {})
-
-    def _read_routes(self):
-        if not self.pod.file_exists(self.routes_path):
-            return
-
-        # The utils parsing causes recursion errors, so needs to be normal yaml.
-        raw_routes = yaml.load(self.pod.read_file(self.routes_path))
-        # Untag to get the right values for the environment.
-        routes = untag.Untag.untag(
-            raw_routes, params={
-                'env': untag.UntagParamRegex(self.pod.env.name),
-            })
-        self.pod_paths = routes['pod_paths']
 
     def get_field(self, pod_path, field, default_value=None):
         """Get document field from metadata."""

--- a/grow/collections/collection_routes.py
+++ b/grow/collections/collection_routes.py
@@ -33,7 +33,12 @@ class CollectionRoutes(object):
             })
         self.pod_paths = routes['pod_paths']
 
+    def localization(self, pod_path, default_value=None):
+        """Get document localization information."""
+        data = self._get_meta(pod_path)
+        return data.get('localization', default_value)
+
     def path(self, pod_path, default_value=None):
-        """Get base serving path """
+        """Get document base serving path."""
         data = self._get_meta(pod_path)
         return data.get('path', default_value)

--- a/grow/collections/collection_routes.py
+++ b/grow/collections/collection_routes.py
@@ -1,0 +1,39 @@
+"""Routing information for the collection."""
+
+import os
+import yaml
+from grow.common import untag
+
+
+class CollectionRoutes(object):
+    """Collection level routing information."""
+
+    ROUTES_PATH = '_routes.yaml'
+
+    def __init__(self, pod, collection_path):
+        self.pod = pod
+        self.collection_path = collection_path
+        self.routes_path = os.path.join(collection_path, self.ROUTES_PATH)
+        self.pod_paths = {}
+        self._read_routes()
+
+    def _get_meta(self, pod_path):
+        return self.pod_paths.get(pod_path, {})
+
+    def _read_routes(self):
+        if not self.pod.file_exists(self.routes_path):
+            return
+
+        # The utils parsing causes recursion errors, so needs to be normal yaml.
+        raw_routes = yaml.load(self.pod.read_file(self.routes_path))
+        # Untag to get the right values for the environment.
+        routes = untag.Untag.untag(
+            raw_routes, params={
+                'env': untag.UntagParamRegex(self.pod.env.name),
+            })
+        self.pod_paths = routes['pod_paths']
+
+    def path(self, pod_path, default_value=None):
+        """Get base serving path """
+        data = self._get_meta(pod_path)
+        return data.get('path', default_value)

--- a/grow/collections/collection_routes.py
+++ b/grow/collections/collection_routes.py
@@ -10,6 +10,11 @@ class CollectionRoutes(object):
 
     ROUTES_PATH = '_routes.yaml'
 
+    def __getattr__(self, attr):
+        def _get_field(pod_path, default_value=None):
+            return self.get_field(pod_path, attr, default_value)
+        return _get_field
+
     def __init__(self, pod, collection_path):
         self.pod = pod
         self.collection_path = collection_path
@@ -33,12 +38,7 @@ class CollectionRoutes(object):
             })
         self.pod_paths = routes['pod_paths']
 
-    def localization(self, pod_path, default_value=None):
-        """Get document localization information."""
+    def get_field(self, pod_path, field, default_value=None):
+        """Get document field from metadata."""
         data = self._get_meta(pod_path)
-        return data.get('localization', default_value)
-
-    def path(self, pod_path, default_value=None):
-        """Get document base serving path."""
-        data = self._get_meta(pod_path)
-        return data.get('path', default_value)
+        return data.get(field, default_value)

--- a/grow/commands/subcommands/convert.py
+++ b/grow/commands/subcommands/convert.py
@@ -6,15 +6,20 @@ from grow.commands import shared
 from grow.common import rc_config
 from grow.pods import pods
 from grow import storage
+from grow.conversion import collection_routing
 from grow.conversion import content_locale_split
 
 
 CFG = rc_config.RC_CONFIG.prefixed('grow.convert')
+CONVERT_CHOICES = [
+    'content_locale_split',
+    'collection_routing',
+]
 
 
 @click.command()
 @shared.pod_path_argument
-@click.option('--type', 'convert_type', type=click.Choice(['content_locale_split']))
+@click.option('--type', 'convert_type', type=click.Choice(CONVERT_CHOICES))
 def convert(pod_path, convert_type):
     """Converts pod files from an earlier version of Grow."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
@@ -22,6 +27,8 @@ def convert(pod_path, convert_type):
 
     if convert_type == 'content_locale_split':
         content_locale_split.Converter.convert(pod)
+    elif convert_type == 'collection_routing':
+        collection_routing.Converter.convert(pod)
     else:
         raise click.UsageError(
             'Unable to convert files without a --type option.\n'

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -170,7 +170,7 @@ class UntagParamLocaleRegex(object):
         """Shortcut from the pod and collection objects."""
         podspec_data = pod.yaml.get('localization', {}).get('groups', {})
         if collection:
-            collection_data = collection.get('localization', {}).get('groups', {})
+            collection_data = collection.fields.get('localization', {}).get('groups', {})
         else:
             collection_data = {}
         return cls(podspec_data, collection_data)

--- a/grow/conversion/__init__.py
+++ b/grow/conversion/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["content_locale_split"]
+__all__ = ["content_locale_split", "collection_routing"]

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -18,16 +18,9 @@ import os
 import yaml
 from grow.common import yaml_utils
 
-try:
-    from yaml import CLoader as yaml_Loader
-except ImportError:
-    from yaml import Loader as yaml_Loader
-
 
 ROUTES_FILENAME = '_routes.yaml'
-COLLECTION_META_KEYS = (
-    '$date', '$dates', '$path', '$localization', '$category', '$parent',
-    '$slug', '$title', '$view')
+COLLECTION_META_KEYS = ('$path', '$localization', '$view')
 
 
 class Error(Exception):

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -1,0 +1,99 @@
+"""
+Utility for converting Grow sites to enable collection level routing. Instead
+of storing things that affect routing directly in the document it is stored
+at the level of the collection to prevent the need to read every document to
+generate the routing information.
+
+WARNING: This feature is used in the `separate_routing` experiment.
+
+Usage:
+
+    grow convert --type=collection_routing
+"""
+
+import collections
+import logging
+import os
+import yaml
+from grow.common import yaml_utils
+
+try:
+    from yaml import CLoader as yaml_Loader
+except ImportError:
+    from yaml import Loader as yaml_Loader
+
+
+ROUTES_FILENAME = '_routes.yaml'
+
+
+class Error(Exception):
+    pass
+
+
+class RoutesData(object):
+    """Store and format the routes information pulled from the documents."""
+
+    def __init__(self):
+        self.paths = collections.OrderedDict()
+
+    @property
+    def data(self):
+        """The yaml contents to write to the file."""
+        data = collections.OrderedDict()
+        data['version'] = 1
+        data['pod_paths'] = self.paths
+        return data
+
+    def extract_doc(self, doc):
+        """Extract the meta information from the doc to use for the routes."""
+        raw_data = doc.format.front_matter.raw_data
+        data = collections.OrderedDict()
+
+        for key, value in raw_data.iteritems():
+            if key == '$path' or key.startswith('$path@'):
+                data[key.lstrip('$')] = value
+            elif key == '$localization' or key.startswith('$localization@'):
+                data[key.lstrip('$')] = value
+
+        self.paths[doc.pod_path] = data
+
+    def write_routes(self, pod, collection):
+        """Write the converted routes to the configuration file."""
+        routes_file = os.path.join(collection.pod_path, ROUTES_FILENAME)
+
+        print 'Writing new routes: {}'.format(routes_file)
+        output = yaml.dump(
+            self.data, Dumper=yaml_utils.PlainTextYamlDumper,
+            default_flow_style=False, allow_unicode=True, width=800)
+        pod.write_file(routes_file, output)
+        print output  # TODO: Remove
+
+class ConversionCollection(object):
+    """Temporary collection class for doing a conversion for a collection."""
+
+    def __init__(self, pod, collection):
+        self.pod = pod
+        self.collection = collection
+        self.routes_data = RoutesData()
+
+    def convert(self):
+        """Perform the conversion to use collection based routing."""
+        print 'Converting: {}'.format(self.collection.pod_path)
+
+        # Pull out the meta information from all the docs.
+        for doc in self.collection.list_docs_unread():
+            self.routes_data.extract_doc(doc)
+
+        self.routes_data.write_routes(self.pod, self.collection)
+
+
+class Converter(object):
+
+    @staticmethod
+    def convert(pod):
+        logging.info('Converting pod for collection level routing: {}'.format(
+            pod.root))
+
+        for collection in pod.list_collections():
+            conv_collection = ConversionCollection(pod, collection)
+            conv_collection.convert()

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -60,12 +60,16 @@ class RoutesData(object):
         """Write the converted routes to the configuration file."""
         routes_file = os.path.join(collection.pod_path, ROUTES_FILENAME)
 
-        print ' └─ Writing: {}'.format(routes_file)
-        print ''
-        output = yaml.dump(
-            self.data, Dumper=yaml_utils.PlainTextYamlDumper,
-            default_flow_style=False, allow_unicode=True, width=800)
-        pod.write_file(routes_file, output)
+        if self.data['pod_paths']:
+            print ' └─ Writing: {}'.format(routes_file)
+            print ''
+            output = yaml.dump(
+                self.data, Dumper=yaml_utils.PlainTextYamlDumper,
+                default_flow_style=False, allow_unicode=True, width=800)
+            pod.write_file(routes_file, output)
+        else:
+            print ' └─ Skipping: {}'.format(routes_file)
+            print ''
 
 
 class ConversionCollection(object):

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Utility for converting Grow sites to enable collection level routing. Instead
 of storing things that affect routing directly in the document it is stored
@@ -24,6 +25,9 @@ except ImportError:
 
 
 ROUTES_FILENAME = '_routes.yaml'
+COLLECTION_META_KEYS = (
+    '$date', '$dates', '$path', '$localization', '$category', '$parent',
+    '$slug', '$title', '$view')
 
 
 class Error(Exception):
@@ -49,10 +53,11 @@ class RoutesData(object):
         raw_data = doc.format.front_matter.raw_data
         data = collections.OrderedDict()
 
+        tagged_keys = tuple(['{}@'.format(key)
+                             for key in COLLECTION_META_KEYS])
+
         for key, value in raw_data.iteritems():
-            if key == '$path' or key.startswith('$path@'):
-                data[key.lstrip('$')] = value
-            elif key == '$localization' or key.startswith('$localization@'):
+            if key in COLLECTION_META_KEYS or key.startswith(tagged_keys):
                 data[key.lstrip('$')] = value
 
         self.paths[doc.pod_path] = data
@@ -61,12 +66,13 @@ class RoutesData(object):
         """Write the converted routes to the configuration file."""
         routes_file = os.path.join(collection.pod_path, ROUTES_FILENAME)
 
-        print 'Writing new routes: {}'.format(routes_file)
+        print ' └─ Writing: {}'.format(routes_file)
+        print ''
         output = yaml.dump(
             self.data, Dumper=yaml_utils.PlainTextYamlDumper,
             default_flow_style=False, allow_unicode=True, width=800)
         pod.write_file(routes_file, output)
-        print output  # TODO: Remove
+
 
 class ConversionCollection(object):
     """Temporary collection class for doing a conversion for a collection."""

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -53,7 +53,8 @@ class RoutesData(object):
             if key in COLLECTION_META_KEYS or key.startswith(tagged_keys):
                 data[key.lstrip('$')] = value
 
-        self.paths[doc.pod_path] = data
+        if data:
+            self.paths[doc.pod_path] = data
 
     def write_routes(self, pod, collection):
         """Write the converted routes to the configuration file."""

--- a/grow/conversion/collection_routing_test.py
+++ b/grow/conversion/collection_routing_test.py
@@ -1,0 +1,19 @@
+"""Tests for converting a pod to use collection level routing."""
+
+import unittest
+from grow import storage
+from grow.pods import pods
+from grow.conversion import collection_routing
+from grow.testing import testing
+
+
+class ConversionDocumentTestCase(unittest.TestCase):
+
+    def setUp(self):
+        dir_path = testing.create_test_pod_dir()
+        self.pod = pods.Pod(dir_path, storage=storage.FileStorage)
+        self.pod.write_yaml('/podspec.yaml', {})
+
+    def test_something(self):
+        """Testing?"""
+        pass

--- a/grow/conversion/content_locale_split.py
+++ b/grow/conversion/content_locale_split.py
@@ -6,7 +6,7 @@ This is required for all versions of Grow after 0.1.0.
 
 Usage:
 
-    grow convert --version=0.1.0
+    grow convert --type=content_locale_split
 """
 
 from boltons import iterutils

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -193,9 +193,9 @@ class Document(object):
     @utils.cached_property
     def default_locale(self):
         """Default document locale."""
-        if self.pod.experiments('separate_routing'):
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
             localization = self.collection.routes.localization(
-                self.pod_path, {})
+                self.collection_path, {})
         else:
             localization = self.format.front_matter.data.get(
                 '$localization', {})
@@ -278,9 +278,9 @@ class Document(object):
 
     @utils.cached_property
     def locales(self):
-        if self.pod.experiments('separate_routing'):
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
             localization = self.collection.routes.localization(
-                self.pod_path, {})
+                self.collection_path, {})
         else:
             # Default to none to be able to override the upstream locales.
             localization = self.fields.get('$localization', {})
@@ -320,28 +320,26 @@ class Document(object):
     @utils.memoize
     def path_format_base(self):
         """Path format for base document."""
-        if self.pod.experiments('separate_routing'):
-            # When using separate routing the path information is stored at the
-            # collection level.
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
             return self.collection.routes.path(
-                self.pod_path, self.collection.path_format)
+                self.collection_path, self.collection.path_format)
         return self.fields.get('$path', self.collection.path_format)
 
     @property
     @utils.memoize
     def path_format_localized(self):
         """Path format for localized documents."""
-        if self.pod.experiments('separate_routing'):
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
             localization = self.collection.routes.localization(
-                self.pod_path, {})
+                self.collection_path, {})
         else:
             localization = self.fields.get('$localization', {})
 
         if 'path' in localization:
             return localization['path']
 
-        if self.pod.experiments('separate_routing'):
-            path_format = self.collection.routes.path(self.pod_path, '')
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
+            path_format = self.collection.routes.path(self.collection_path, '')
         else:
             path_format = self.fields.get('$path', '')
 
@@ -421,8 +419,9 @@ class Document(object):
 
     @property
     def view(self):
-        if self.pod.experiments('separate_routing'):
-            view_format = self.collection.routes.view(self.pod_path, self.collection.view)
+        if self.collection.features(self.collection.FEATURE_SEPARATE_ROUTING):
+            view_format = self.collection.routes.view(
+                self.collection_path, self.collection.view)
         else:
             view_format = self.fields.get('$view', self.collection.view)
         if view_format is not None:

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -289,10 +289,11 @@ class Document(object):
             localization = self.collection.routes.localization(
                 self.pod_path, {})
         else:
+            # Default to none to be able to override the upstream locales.
             localization = self.fields.get('$localization', {})
 
         # Disable localization with $localization:~.
-        if not localization:
+        if localization is None:
             return []
         if 'locales' in localization:
             codes = localization['locales'] or []

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -165,8 +165,6 @@ class Document(object):
 
     @property
     def category(self):
-        if self.pod.experiments('separate_routing'):
-            return self.collection.routes.category(self.pod_path)
         return self.fields.get('$category')
 
     @property
@@ -185,16 +183,11 @@ class Document(object):
 
     @property
     def date(self):
-        if self.pod.experiments('separate_routing'):
-            return self.collection.routes.date(self.pod_path)
         return self.fields.get('$date')
 
     @property
     def dates(self):
         """Built in field for dates."""
-        if self.pod.experiments('separate_routing'):
-            return structures.AttributeDict(
-                self.collection.routes.dates(self.pod_path, {}))
         return structures.AttributeDict(self.fields.get('$dates', {}))
 
     @utils.cached_property
@@ -308,10 +301,7 @@ class Document(object):
     @property
     @utils.memoize
     def parent(self):
-        if self.pod.experiments('separate_routing'):
-            parent_pod_path = self.collection.routes.parent(self.pod_path)
-        else:
-            parent_pod_path = self.fields.get('$parent')
+        parent_pod_path = self.fields.get('$parent')
         if not parent_pod_path:
             return None
         return self.collection.get_doc(parent_pod_path, locale=self.locale)
@@ -402,10 +392,7 @@ class Document(object):
 
     @property
     def slug(self):
-        if self.pod.experiments('separate_routing'):
-            value = self.collection.routes.slug(self.pod_path)
-        else:
-            value = self.fields.get('$slug')
+        value = self.fields.get('$slug')
         if value:
             return value
         return utils.slugify(self.title) if self.title is not None else None
@@ -416,10 +403,7 @@ class Document(object):
 
     @property
     def title(self):
-        if self.pod.experiments('separate_routing'):
-            return self.collection.routes.title(self.pod_path)
-        else:
-            return self.fields.get('$title')
+        return self.fields.get('$title')
 
     @utils.cached_property
     def translation_stats(self):

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -207,7 +207,7 @@ class Document(object):
             localization = self.format.front_matter.data.get(
                 '$localization', {})
 
-        if 'default_locale' in localization:
+        if localization and 'default_locale' in localization:
             return self.pod.normalize_locale(localization['default_locale'])
         return self.collection.default_locale
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -100,7 +100,7 @@ class Pod(object):
         self._features = features.Features(disabled=[
             self.FEATURE_TRANSLATION_STATS,
         ])
-        self._experiments = features.Features()
+        self._experiments = features.Features(default_enabled=False)
 
         self._extensions_controller = ext_controller.ExtensionController(self)
 

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -53,24 +53,8 @@ class PathFormat(object):
 
         # Most params should always be replaced.
         params = self.params_pod()
-        params['base'] = doc.base
-        params['category'] = doc.category
-        params['collection'] = structures.AttributeDict(
-            base_path=doc.collection_base_path,
-            basename=doc.collection.basename,
-            root=doc.collection.root)
-        params['parent'] = doc.parent if doc.parent else utils.DummyDict()
-        params['slug'] = doc.slug
-
-        if isinstance(doc.date, datetime.datetime):
-            params['date'] = doc.date.date()
-        else:
-            params['date'] = doc.date
-
-        if '|lower' in path:
-            for key, value in params.items():
-                if isinstance(value, basestring):
-                    params['{}|lower'.format(key)] = value.lower()
+        params.update(self.params_doc(path, doc))
+        params = self.params_lower(path, params)
 
         path = utils.safe_format(path, **params)
 
@@ -114,9 +98,7 @@ class PathFormat(object):
         if fingerprint:
             params['fingerprint'] = fingerprint
 
-        locale_alias = self._locale_or_alias(locale)
-        if locale_alias:
-            params['locale'] = locale_alias
+        params['locale'] = self._locale_or_alias(locale)
 
         if params:
             path = utils.safe_format(path, **params)
@@ -129,24 +111,8 @@ class PathFormat(object):
 
         # Most params should always be replaced.
         params = self.params_pod()
-        params['base'] = doc.base
-        params['category'] = doc.category
-        params['collection'] = structures.AttributeDict(
-            base_path=doc.collection_base_path,
-            basename=doc.collection.basename,
-            root=doc.collection.root)
-        params['parent'] = doc.parent if doc.parent else utils.DummyDict()
-        params['slug'] = doc.slug
-
-        if isinstance(doc.date, datetime.datetime):
-            params['date'] = doc.date.date()
-        else:
-            params['date'] = doc.date
-
-        if '|lower' in path:
-            for key, value in params.items():
-                if isinstance(value, basestring):
-                    params['{}|lower'.format(key)] = value.lower()
+        params.update(self.params_doc(path, doc))
+        params = self.params_lower(path, params)
 
         path = utils.safe_format(path, **params)
 
@@ -154,6 +120,35 @@ class PathFormat(object):
             path = self.parameterize(path)
 
         return self.strip_double_slash(path)
+
+    def params_doc(self, path, doc):
+        """Selective access to the document properties depending on path."""
+        params = {}
+        params['base'] = doc.base
+        params['collection'] = structures.AttributeDict(
+            base_path=doc.collection_base_path,
+            basename=doc.collection.basename,
+            root=doc.collection.root)
+        if '{category}' in path:
+            params['category'] = doc.category
+        if '{parent}' in path:
+            params['parent'] = doc.parent if doc.parent else utils.DummyDict()
+        if '{slug}' in path:
+            params['slug'] = doc.slug
+        if '{date}' in path:
+            if isinstance(doc.date, datetime.datetime):
+                params['date'] = doc.date.date()
+            else:
+                params['date'] = doc.date
+        return params
+
+    def params_lower(self, path, params):
+        """Update to support lowercase when in the path."""
+        if '|lower' in path:
+            for key, value in params.items():
+                if isinstance(value, basestring):
+                    params['{}|lower'.format(key)] = value.lower()
+        return params
 
     def params_pod(self):
         params = {}


### PR DESCRIPTION
Move major pieces of the routing out of the documents and use a collection level `_routing.yaml` to handle document specific `localization`, `path`, and `view` information.

- Improves the rate that the routes load (speeds up `grow run` command).
- Removes(?) the need to do correction on the default locale for a document since the document doesn't need to be loaded to know what the default locale is.