### PR TITLE
Enhancements to strings preprocessor and !g.string

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -49,6 +49,10 @@ class UnavailableError(Error):
     """Raised when a feature is not available."""
 
 
+class DraftStringError(Error):
+    """Raised when a draft string is used yet not allowed."""
+
+
 def is_packaged_app():
     """Returns whether the environment is a packaged app."""
     try:
@@ -341,6 +345,9 @@ def make_yaml_loader(pod, doc=None, locale=None, untag_params=None):
                 if reference:
                     data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
                     try:
+                        allow_draft = pod.podspec.fields.get('strings', {}).get('allow_draft')
+                        if allow_draft is False and data.get('$draft'):
+                            raise DraftStringError('Encountered string in draft -> {}?{}'.format(path, reference))
                         value = data[reference]
                         if value is None:
                             if doc:

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -37,6 +37,7 @@ except ImportError:
 APPENGINE_SERVER_PREFIXES = ('Development/', 'Google App Engine/')
 LOCALIZED_KEY_REGEX = re.compile('(.*)@([^@]+)$')
 SENTINEL = object()
+DRAFT_KEY = '$draft'
 SLUG_REGEX = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
 SLUG_SUBSTITUTE = ((':{}', ':'),)
 
@@ -346,7 +347,7 @@ def make_yaml_loader(pod, doc=None, locale=None, untag_params=None):
                     data = structures.DeepReferenceDict(self.read_yaml(path, locale=locale))
                     try:
                         allow_draft = pod.podspec.fields.get('strings', {}).get('allow_draft')
-                        if allow_draft is False and data.get('$draft'):
+                        if allow_draft is False and data.get(DRAFT_KEY):
                             raise DraftStringError('Encountered string in draft -> {}?{}'.format(path, reference))
                         value = data[reference]
                         if value is None:

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -387,7 +387,7 @@ class GoogleSheetsPreprocessor(BaseGooglePreprocessor):
             if META_KEY not in new_data:
                 new_data[META_KEY] = {}
             if 'properties' not in new_data[META_KEY]:
-                new_data[META_KEY]['properties']: {}
+                new_data[META_KEY]['properties'] = {}
             for name in self.config.include_properties:
                 if name in properties:
                     new_data[META_KEY]['properties'][name] = properties[name]

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -128,13 +128,13 @@ class GoogleDocsPreprocessor(BaseGooglePreprocessor):
             docs_to_add = []
             existing_docs = self.pod.list_dir(config.collection)
             for item in resp['items']:
-                if item['mimeType'] != 'application/vnd.google-apps.document':
-                    continue
-                if item['title'].startswith(IGNORE_INITIAL):
-                    self.pod.logger.info('Skipping -> {}'.format(title))
-                    continue
                 doc_id = item['id']
                 title = item['title']
+                if item['mimeType'] != 'application/vnd.google-apps.document':
+                    continue
+                if title.startswith(IGNORE_INITIAL):
+                    self.pod.logger.info('Skipping -> {}'.format(title))
+                    continue
                 basename = '{}.md'.format(utils.slugify(title))
                 docs_to_add.append(basename)
                 path = os.path.join(config.collection, basename)

--- a/grow/preprocessors/google_drive_test.py
+++ b/grow/preprocessors/google_drive_test.py
@@ -233,7 +233,6 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
                   {'age': 23, 'id': '2', 'name': 'Sue'}],
             765: [{'age': 27, 'id': '1', 'name': 'Jim'},
                   {'age': 23, 'id': '2', 'name': 'Sue'}],
-            922: [],
         }, gid_to_data)
 
     @mock.patch.object(google_drive.BaseGooglePreprocessor, 'create_service')
@@ -327,7 +326,6 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
                   {'age': 23, 'id': '2', 'name': 'Sue'}],
             765: [{'age': 27, 'id': '1', 'name': 'Jim'},
                   {'age': 23, 'id': '2', 'name': 'Sue'}],
-            922: [],
         }, gid_to_data)
 
     @mock.patch.object(google_drive.BaseGooglePreprocessor, 'create_service')

--- a/grow/preprocessors/google_drive_test.py
+++ b/grow/preprocessors/google_drive_test.py
@@ -22,13 +22,18 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
         self.pod = pods.Pod(dir_path, storage=storage.FileStorage)
 
     @staticmethod
-    def _setup_mocks(sheets_get=None, sheets_values=None, files=None):
+    def _setup_mocks(sheets_get=None, sheets_values=None,
+                     sheets_batch_values=None, files=None):
         if sheets_get is None:
             sheets_get = {
                 'spreadsheetId': 76543,
             }
-        if sheets_values is None:
-            sheets_values = []
+        if sheets_batch_values is None:
+            if sheets_values is None:
+                sheets_values = []
+            sheets_batch_values = {'valueRanges': [sheets_values]}
+        else:
+            sheets_batch_values = {'valueRanges': sheets_batch_values}
 
         if files is None:
             files = {
@@ -42,7 +47,7 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
             }
 
         mock_sheets_service = google_service.GoogleServiceMock.mock_sheets_service(
-            get=sheets_get, values=sheets_values, files=files)
+            get=sheets_get, batch_values=sheets_batch_values, files=files)
 
         return mock_sheets_service
 
@@ -174,13 +179,25 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
                     },
                 },
             }]
-        }, sheets_values={
+        }, sheets_batch_values=[{
             'values': [
                 ['id', 'name', 'age', '_comment'],
                 ['1', 'Jim', 27, 'commenting'],
                 ['2', 'Sue', 23, 'something'],
             ],
-        })
+        }, {
+            'values': [
+                ['id', 'name', 'age', '_comment'],
+                ['1', 'Jim', 27, 'commenting'],
+                ['2', 'Sue', 23, 'something'],
+            ],
+        }, {
+            'values': [
+                ['id', 'name', 'age', '_comment'],
+                ['1', 'Jim', 27, 'commenting'],
+                ['2', 'Sue', 23, 'something'],
+            ],
+        }])
         mock_service_sheets.return_value = mock_sheets_service['service']
         gid_to_sheet, gid_to_data = preprocessor.download('A1B2C3D4E5F6')
 
@@ -252,14 +269,28 @@ class GoogleSheetsPreprocessorTest(unittest.TestCase):
                     },
                 },
             }]
-        }, sheets_values={
+        }, sheets_batch_values=[{
             'values': [
                 ['', 'ignored1', 'ignored2', 'ignored3'],
                 ['id', 'name', 'age', '_comment'],
                 ['1', 'Jim', 27, 'commenting'],
                 ['2', 'Sue', 23, 'something'],
             ],
-        })
+        }, {
+            'values': [
+                ['', 'ignored1', 'ignored2', 'ignored3'],
+                ['id', 'name', 'age', '_comment'],
+                ['1', 'Jim', 27, 'commenting'],
+                ['2', 'Sue', 23, 'something'],
+            ],
+        }, {
+            'values': [
+                ['', 'ignored1', 'ignored2', 'ignored3'],
+                ['id', 'name', 'age', '_comment'],
+                ['1', 'Jim', 27, 'commenting'],
+                ['2', 'Sue', 23, 'something'],
+            ],
+        }])
         mock_service_sheets.return_value = mock_sheets_service['service']
         gid_to_sheet, gid_to_data = preprocessor.download('A1B2C3D4E5F6',
             header_row_count=2, header_row_index=2)

--- a/grow/testing/google_service.py
+++ b/grow/testing/google_service.py
@@ -34,7 +34,7 @@ class GoogleServiceMock(object):
         }
 
     @classmethod
-    def mock_sheets_service(cls, create=None, get=None, values=None, files=None):
+    def mock_sheets_service(cls, create=None, get=None, values=None, batch_values=None, files=None):
         """Create mock for a google sheets service."""
         mock_files = mock.Mock()
         mock_files_get = mock.Mock()
@@ -56,8 +56,11 @@ class GoogleServiceMock(object):
 
         mock_values_get = mock.Mock()
         mock_values_get.execute.return_value = values
+        mock_values_batch_get = mock.Mock()
+        mock_values_batch_get.execute.return_value = batch_values
         mock_values = mock.Mock()
         mock_values.get.return_value = mock_values_get
+        mock_values.batchGet.return_value = mock_values_batch_get
         mock_spreadsheets.values.return_value = mock_values
 
         mock_service = mock.Mock()


### PR DESCRIPTION
Background:
We need a way to further introduce workflow features into Google Sheets Copy CMS documents. This PR adds the ability to block strings from being published (yet still used in development), block strings from being downloaded (using `*` in the tab title as a dirty marker), and adds a few other workflow enhancements to the Google Sheets/strings integration.

Changes:
- Uses `batchGet` instead of `get` to drastically improve Google Sheet/tab download time.
- Simplify logging output for Google Sheets preprocessor.
- Adds new `include_properties` option to Sheets preprocessor that downloads specified properties into the `$meta:properties` key of the strings YAML file.
- Adds new `draft_as_color` option (default `True`) to Sheets preprocessor that, when detecting that the Google Sheets tab's color is "red", `$draft: true` is set on the strings YAML file.
- Adds new `strings` setting in `podspec.yaml`.
- Adds new `allow_draft` option in `strings` setting, which, when set to `False`, will raise an error if the build encounters a draft string. This is intended to be used with `@env` tagging, permitting strings to be used in development and staging, but blocked from production environments.

Samples:

```
# podspec.yaml
strings:
  # Words that should never appear in prod (case insensitive).
  # NOTE: No changes implemented in this PR for this feature;
  # this is intended to be consumed by project-specific macros for now.
  blacklist_words@env.prod:
  - Secret Product Name
  - Secret Product Feature
  # Raises an error if any strings marked `$draft: true` are encountered building a page.
  allow_draft@env.prod: false

preprocessors:
- kind: google_sheets
  id: ...
  format: grid
  collection: /content/strings/
  include_properties:
  - tabColor

# /content/strings/foo.yaml
$draft: true
$meta:
  properties:
    tabColor:
      red: 1
qaz:
  title@: qux
```