### PR TITLE
Adding a filter for string formatting using the newer string format

### DIFF
--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -54,6 +54,12 @@ def expand_partial(_ctx, partial_name):
 
 
 @jinja2.contextfilter
+def format_str(_ctx, source, *args, **kwargs):
+    """Filter for formatting a string using the newage formatting."""
+    return source.format(*args, **kwargs)
+
+
+@jinja2.contextfilter
 def hash_value(_ctx, value, algorithm='sha'):
     """Hash the value using the algorithm."""
     if algorithm in ('md5',):
@@ -159,6 +165,7 @@ def create_builtin_filters():
         ('decimal', wrap_locale_context(babel_numbers.format_decimal)),
         ('deeptrans', deeptrans),
         ('expand_partial', expand_partial),
+        ('format_str', format_str),
         ('hash', hash_value),
         ('jsonify', jsonify),
         ('markdown', markdown_filter),

--- a/grow/templates/filters_test.py
+++ b/grow/templates/filters_test.py
@@ -13,6 +13,11 @@ class BuiltinsTestCase(unittest.TestCase):
         self.dir_path = testing.create_test_pod_dir()
         self.pod = pods.Pod(self.dir_path, storage=storage.FileStorage)
 
+    def test_format_str(self):
+        original = 'testing {} positional and {key} keywords'
+        expected = 'testing the positional and alt keywords'
+        self.assertEqual(expected, filters.format_str(None, original, 'the', key='alt'))
+
     def test_shuffle_filter(self):
         words = ['foo', 'bar', 'baz']
         self.assertIn('foo', filters.shuffle_filter(None, words))


### PR DESCRIPTION
Normal Jinja `format` filter: `{{ "%s - %s"|format("Hello?", "Foo!") }}`
New `format_str` filter: `{{ "{} - {}"|format_str("Hello?", "Foo!") }}`