### PR TITLE
Fixing how dynamic paths are dedeuplicated when doing dynamic routes.

### DIFF
--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -64,21 +64,21 @@ class Router(object):
                 doc_basenames = set()
                 for doc in collection.list_docs_unread():
                     # Skip duplicate documents when using non-concrete routing.
-                    if not concrete and doc.basename in doc_basenames:
+                    if not concrete and doc.collection_path in doc_basenames:
                         continue
                     is_default_locale = doc._locale_kwarg == self.pod.podspec.default_locale
                     # Ignore localized names in the files since they will be
                     # picked up when the locales are expanded.
                     if doc.root_pod_path == doc.pod_path or is_default_locale:
                         docs.append(doc)
-                        doc_basenames.add(doc.basename)
+                        doc_basenames.add(doc.collection_path)
                     else:
                         # If this document does not exist with the default
                         # locale it still needs to be added.
                         locale_doc = self.pod.get_doc(doc.pod_path, doc.default_locale)
                         if not locale_doc.exists:
                             docs.append(doc)
-                            doc_basenames.add(doc.basename)
+                            doc_basenames.add(doc.collection_path)
             docs = self._preload_and_expand(docs, expand=concrete)
             self.add_docs(docs, concrete=concrete)
 


### PR DESCRIPTION
When using the local dev server, some paths are not correctly making it into the routing trie.

Specifically when there are two docs that have the same basename it is deduplicating them. For example `/content/col/sub1/docA.yaml` and `/content/col/sub2/docA.yaml` are being seen as duplicates when the intent is to find `/content/col/sub1/docA.yaml` and `/content/col/sub1/docA@es.yaml` as duplicate.