### PR TITLE
Switch out the slugify with a library

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,11 +1,9 @@
 # Grow Dependencies
 
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
-
 
 [packages]
 babel = "==2.7.0"
@@ -35,6 +33,7 @@ protorpc = "==0.11.1"
 "pyasn1" = "==0.4.5"
 pycrypto = "==2.6.1"
 pygments = "==2.4.2"
+python-slugify = "==3.0.2"
 pytz = "==2019.1"
 pyyaml = "==5.1"
 requests = "==2.22.0"
@@ -48,7 +47,6 @@ watchdog = "==0.9.0"
 webob = "==1.8.5"
 webreview = "==0.1.3"
 werkzeug = "==0.15.4"
-
 
 [dev-packages]
 astroid = "==1.6.6"
@@ -72,7 +70,5 @@ twine = "==1.13.0"
 "webapp2" = "==2.5.2"
 funcsigs = "*"
 
-
 [requires]
-
 python_version = "2.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78023016da4d49aae177e37ea8dde1d10de84915c056247ec9b1625a59e63bfb"
+            "sha256": "ace5e1ac4c1e47931c399f36818990ddcb1cecd290df94395f21a712a057f498"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -454,6 +454,13 @@
             ],
             "version": "==19.0.0"
         },
+        "python-slugify": {
+            "hashes": [
+                "sha256:57163ffb345c7e26063435a27add1feae67fa821f1ef4b2f292c25847575d758"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
         "python-utils": {
             "hashes": [
                 "sha256:34aaf26b39b0b86628008f2ae0ac001b30e7986a8d303b61e1357dfcdad4f6d3",
@@ -542,6 +549,13 @@
                 "sha256:b20eff5e564529711544066d7dc0f7661df41232ae263619dede5059799cdfca"
             ],
             "version": "==1.9.1"
+        },
+        "text-unidecode": {
+            "hashes": [
+                "sha256:5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d",
+                "sha256:801e38bd550b943563660a91de8d4b6fa5df60a542be9093f7abf819f86050cc"
+            ],
+            "version": "==1.2"
         },
         "texttable-fixed": {
             "hashes": [

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -69,7 +69,6 @@ class WebReviewDestination(base.BaseDestination):
             api_key = os.getenv('WEBREVIEW_API_KEY')
             subdomain = self._get_subdomain()
             self._webreview = webreview.WebReview(
-                pod=self.pod,
                 project=self.config.project,
                 name=subdomain,
                 host=self.config.server,

--- a/grow/deployments/destinations/webreview_destination.py
+++ b/grow/deployments/destinations/webreview_destination.py
@@ -69,6 +69,7 @@ class WebReviewDestination(base.BaseDestination):
             api_key = os.getenv('WEBREVIEW_API_KEY')
             subdomain = self._get_subdomain()
             self._webreview = webreview.WebReview(
+                pod=self.pod,
                 project=self.config.project,
                 name=subdomain,
                 host=self.config.server,

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -1,11 +1,11 @@
 """Grow documents."""
 
-import datetime
 import json
 import logging
 import os
 import re
 import yaml
+from slugify import slugify
 from grow.common import structures
 from grow.common import untag
 from grow.common import urls
@@ -398,7 +398,11 @@ class Document(object):
         value = self.fields.get('$slug')
         if value:
             return value
-        return utils.slugify(self.title) if self.title is not None else None
+        if not self.title:
+            return None
+        if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+            return utils.slugify(self.title)
+        return slugify(self.title)
 
     @property
     def sitemap(self):

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -4,8 +4,8 @@ import json
 import logging
 import os
 import re
+import slugify
 import yaml
-from slugify import slugify
 from grow.common import structures
 from grow.common import untag
 from grow.common import urls
@@ -402,7 +402,7 @@ class Document(object):
             return None
         if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
             return utils.slugify(self.title)
-        return slugify(self.title)
+        return slugify.slugify(self.title)
 
     @property
     def sitemap(self):

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -400,7 +400,7 @@ class Document(object):
             return value
         if not self.title:
             return None
-        if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+        if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
             return utils.slugify(self.title)
         return slugify(self.title)
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -594,7 +594,7 @@ class Pod(object):
                 kwargs['bytecode_cache'] = self._get_bytecode_cache()
             kwargs['extensions'].extend(self.list_jinja_extensions())
             env = jinja_dependency.DepEnvironment(**kwargs)
-            env.filters.update(filters.create_builtin_filters(env, self.pod, locale=locale))
+            env.filters.update(filters.create_builtin_filters(env, self, locale=locale))
             env.globals.update(
                 **tags.create_builtin_globals(env, self, locale=locale))
             return env

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -76,6 +76,7 @@ class Pod(object):
     DEFAULT_EXTENSIONS_DIR_NAME = 'extensions'
     FEATURE_UI = 'ui'
     FEATURE_TRANSLATION_STATS = 'translation_stats'
+    FEATURE_OLD_SLUGIFY = 'legacy_slugify'
     FILE_DEP_CACHE = '.depcache.json'
     FILE_PODSPEC = 'podspec.yaml'
     FILE_EXTENSIONS = 'extensions.txt'

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -149,10 +149,13 @@ class Pod(object):
     def _load_experiments(self):
         config = self.yaml.get('experiments', {})
         for key, value in config.iteritems():
-            # Features can be turned on with a True value
-            # or provide configuration settings through the value.
+            # Expertiments can be turned on with a True value,
+            # be turned off with a False value,
+            # or turned on by a providing configuration value.
             if value is True:
                 self._experiments.enable(key)
+            elif value is False:
+                self._experiments.disable(key)
             else:
                 self._experiments.enable(key, config=value)
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -100,6 +100,7 @@ class Pod(object):
         self._podcache = None
         self._features = features.Features(disabled=[
             self.FEATURE_TRANSLATION_STATS,
+            self.FEATURE_OLD_SLUGIFY,
         ])
         self._experiments = features.Features(default_enabled=False)
 

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -578,7 +578,7 @@ class Pod(object):
                 kwargs['bytecode_cache'] = self._get_bytecode_cache()
             kwargs['extensions'].extend(self.list_jinja_extensions())
             env = jinja_dependency.DepEnvironment(**kwargs)
-            env.filters.update(filters.create_builtin_filters())
+            env.filters.update(filters.create_builtin_filters(env, self.pod, locale=locale))
             env.globals.update(
                 **tags.create_builtin_globals(env, self, locale=locale))
             return env

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -149,8 +149,8 @@ class Pod(object):
     def _load_experiments(self):
         config = self.yaml.get('experiments', {})
         for key, value in config.iteritems():
-            # Experiments can be turned on with a True value.
-            # But the true does does not act as a configuration.
+            # Features can be turned on with a True value
+            # or provide configuration settings through the value.
             if value is True:
                 self._experiments.enable(key)
             else:
@@ -166,8 +166,9 @@ class Pod(object):
     def _load_features(self):
         config = self.yaml.get('features', {})
         for key, value in config.iteritems():
-            # Features can be turned on with a True value.
-            # But the true does does not act as a configuration.
+            # Features can be turned on with a True value,
+            # be turned off with a False value,
+            # or turned on by a providing configuration value.
             if value is True:
                 self._features.enable(key)
             elif value is False:

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -112,6 +112,9 @@ class Pod(object):
             if os.path.exists(_ext_dir):
                 sys.path.insert(0, _ext_dir)
 
+            # Load the features from the podspec.
+            self._load_features()
+
             # Load the experiments from the podspec.
             self._load_experiments()
 
@@ -159,6 +162,18 @@ class Pod(object):
         if load_local_extensions and self.exists:
             self._extensions_controller.register_extensions(
                 self.yaml.get('ext', []))
+
+    def _load_features(self):
+        config = self.yaml.get('features', {})
+        for key, value in config.iteritems():
+            # Features can be turned on with a True value.
+            # But the true does does not act as a configuration.
+            if value is True:
+                self._features.enable(key)
+            elif value is False:
+                self._features.disable(key)
+            else:
+                self._features.enable(key, config=value)
 
     def _normalize_path(self, pod_path):
         if '..' in pod_path:

--- a/grow/pods/ui.py
+++ b/grow/pods/ui.py
@@ -22,5 +22,5 @@ def create_jinja_env():
             'jinja2.ext.loopcontrols',
             'jinja2.ext.with_',
         ])
-    env.filters.update(filters.create_builtin_filters(env, None, locale=locale))
+    env.filters.update(filters.create_builtin_filters(env, None))
     return env

--- a/grow/pods/ui.py
+++ b/grow/pods/ui.py
@@ -22,5 +22,5 @@ def create_jinja_env():
             'jinja2.ext.loopcontrols',
             'jinja2.ext.with_',
         ])
-    env.filters.update(filters.create_builtin_filters(env, self.pod, locale=locale))
+    env.filters.update(filters.create_builtin_filters(env, None, locale=locale))
     return env

--- a/grow/pods/ui.py
+++ b/grow/pods/ui.py
@@ -22,5 +22,5 @@ def create_jinja_env():
             'jinja2.ext.loopcontrols',
             'jinja2.ext.with_',
         ])
-    env.filters.update(filters.create_builtin_filters())
+    env.filters.update(filters.create_builtin_filters(env, self.pod, locale=locale))
     return env

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -138,7 +138,7 @@ class GoogleDocsPreprocessor(BaseGooglePreprocessor):
                 if title.startswith(IGNORE_INITIAL):
                     self.pod.logger.info('Skipping -> {}'.format(title))
                     continue
-                if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+                if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
                     basename = '{}.md'.format(utils.slugify(title))
                 else:
                     basename = '{}.md'.format(slugify(title))
@@ -480,7 +480,7 @@ class GoogleSheetsPreprocessor(BaseGooglePreprocessor):
                 title = gid_to_sheet[gid]['title']
                 if title.strip().startswith(IGNORE_INITIAL):
                     continue
-                if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+                if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
                     slug = utils.slugify(title)
                 else:
                     slug = slugify(title)

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -18,6 +18,7 @@ import httplib2
 from googleapiclient import discovery
 from googleapiclient import errors
 from protorpc import messages
+from slugify import slugify
 from grow.common import oauth
 from grow.common import untag
 from grow.common import utils
@@ -137,7 +138,10 @@ class GoogleDocsPreprocessor(BaseGooglePreprocessor):
                 if title.startswith(IGNORE_INITIAL):
                     self.pod.logger.info('Skipping -> {}'.format(title))
                     continue
-                basename = '{}.md'.format(utils.slugify(title))
+                if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+                    basename = '{}.md'.format(utils.slugify(title))
+                else:
+                    basename = '{}.md'.format(slugify(title))
                 docs_to_add.append(basename)
                 path = os.path.join(config.collection, basename)
                 self._execute_doc(path, doc_id, convert)
@@ -476,7 +480,10 @@ class GoogleSheetsPreprocessor(BaseGooglePreprocessor):
                 title = gid_to_sheet[gid]['title']
                 if title.strip().startswith(IGNORE_INITIAL):
                     continue
-                slug = utils.slugify(title)
+                if self.pod.features(self.pod.FEATURE_OLD_SLUGIFY):
+                    slug = utils.slugify(title)
+                else:
+                    slug = slugify(title)
                 file_name = '{}.yaml'.format(slug)
                 output_path = os.path.join(collection_path, file_name)
                 gid_to_data[gid] = self._maybe_preserve_content(

--- a/grow/preprocessors/google_drive.py
+++ b/grow/preprocessors/google_drive.py
@@ -15,10 +15,10 @@ import json
 import logging
 import os
 import httplib2
+import slugify
 from googleapiclient import discovery
 from googleapiclient import errors
 from protorpc import messages
-from slugify import slugify
 from grow.common import oauth
 from grow.common import untag
 from grow.common import utils
@@ -141,7 +141,7 @@ class GoogleDocsPreprocessor(BaseGooglePreprocessor):
                 if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
                     basename = '{}.md'.format(utils.slugify(title))
                 else:
-                    basename = '{}.md'.format(slugify(title))
+                    basename = '{}.md'.format(slugify.slugify(title))
                 docs_to_add.append(basename)
                 path = os.path.join(config.collection, basename)
                 self._execute_doc(path, doc_id, convert)
@@ -483,7 +483,7 @@ class GoogleSheetsPreprocessor(BaseGooglePreprocessor):
                 if self.pod.is_enabled(self.pod.FEATURE_OLD_SLUGIFY):
                     slug = utils.slugify(title)
                 else:
-                    slug = slugify(title)
+                    slug = slugify.slugify(title)
                 file_name = '{}.yaml'.format(slug)
                 output_path = os.path.join(collection_path, file_name)
                 gid_to_data[gid] = self._maybe_preserve_content(

--- a/grow/rendering/render_pool.py
+++ b/grow/rendering/render_pool.py
@@ -77,7 +77,7 @@ class RenderPool(object):
         kwargs['bytecode_cache'] = self.pod.jinja_bytecode_cache
         kwargs['extensions'].extend(self.pod.list_jinja_extensions())
         env = jinja_dependency.DepEnvironment(**kwargs)
-        env.filters.update(filters.create_builtin_filters())
+        env.filters.update(filters.create_builtin_filters(env, self.pod, locale=locale))
         env.globals.update(**tags.create_builtin_globals(env, self.pod, locale=locale))
         env.tests.update(jinja_tests.create_builtin_tests())
         return env

--- a/grow/storage/file_storage.py
+++ b/grow/storage/file_storage.py
@@ -4,7 +4,6 @@ import jinja2
 import os
 import shutil
 
-
 class FileStorage(base_storage.BaseStorage):
 
     @staticmethod

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -137,7 +137,7 @@ def regex_replace():
 
 def slug_filter(pod):
     """Filters string to remove url unfriendly characters."""
-    use_legacy_slugify = pod.is_enabled(pod.FEATURE_OLD_SLUGIFY)
+    use_legacy_slugify = pod and pod.is_enabled(pod.FEATURE_OLD_SLUGIFY)
     def _slug_filter(value, delimiter=u'-'):
         if use_legacy_slugify:
             return utils.slugify(value, delimiter)

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -137,7 +137,7 @@ def regex_replace():
 
 def slug_filter(pod):
     """Filters string to remove url unfriendly characters."""
-    use_legacy_slugify = pod.features(pod.FEATURE_OLD_SLUGIFY)
+    use_legacy_slugify = pod.is_enabled(pod.FEATURE_OLD_SLUGIFY)
     def _slug_filter(value, delimiter=u'-'):
         if use_legacy_slugify:
             return utils.slugify(value, delimiter)

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -7,9 +7,9 @@ import json as json_lib
 import random
 import re
 import jinja2
+import slugify
 from babel import dates as babel_dates
 from babel import numbers as babel_numbers
-from slugify import slugify
 from grow.common import json_encoder
 from grow.common import urls
 from grow.common import utils
@@ -141,7 +141,7 @@ def slug_filter(pod=None):
     def _slug_filter(value, delimiter=u'-'):
         if use_legacy_slugify:
             return utils.slugify(value, delimiter)
-        return slugify(value, separator=delimiter)
+        return slugify.slugify(value, separator=delimiter)
     return _slug_filter
 
 

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -9,6 +9,7 @@ import re
 import jinja2
 from babel import dates as babel_dates
 from babel import numbers as babel_numbers
+from slugify import slugify
 from grow.common import json_encoder
 from grow.common import urls
 from grow.common import utils
@@ -134,9 +135,14 @@ def regex_replace():
     return regex_replace_filter
 
 
-def slug_filter(value, delimiter=u'-'):
+def slug_filter(pod):
     """Filters string to remove url unfriendly characters."""
-    return utils.slugify(value, delimiter)
+    use_legacy_slugify = pod.features(pod.FEATURE_OLD_SLUGIFY)
+    def _slug_filter(value, delimiter=u'-'):
+        if use_legacy_slugify:
+            return utils.slugify(value, delimiter)
+        return slugify(value, separator=delimiter)
+    return _slug_filter
 
 
 def wrap_locale_context(func):
@@ -150,7 +156,7 @@ def wrap_locale_context(func):
     return _locale_filter
 
 
-def create_builtin_filters():
+def create_builtin_filters(env, pod, locale=None):
     """Filters standard for the template rendering."""
     return (
         ('currency', wrap_locale_context(babel_numbers.format_currency)),
@@ -168,6 +174,6 @@ def create_builtin_filters():
         ('re_replace', regex_replace()),
         ('render', render_filter),
         ('shuffle', shuffle_filter),
-        ('slug', slug_filter),
+        ('slug', slug_filter(pod=pod)),
         ('time', wrap_locale_context(babel_dates.format_time)),
     )

--- a/grow/templates/filters.py
+++ b/grow/templates/filters.py
@@ -135,7 +135,7 @@ def regex_replace():
     return regex_replace_filter
 
 
-def slug_filter(pod):
+def slug_filter(pod=None):
     """Filters string to remove url unfriendly characters."""
     use_legacy_slugify = pod and pod.is_enabled(pod.FEATURE_OLD_SLUGIFY)
     def _slug_filter(value, delimiter=u'-'):
@@ -156,7 +156,7 @@ def wrap_locale_context(func):
     return _locale_filter
 
 
-def create_builtin_filters(env, pod, locale=None):
+def create_builtin_filters(env, pod=None, locale=None):
     """Filters standard for the template rendering."""
     return (
         ('currency', wrap_locale_context(babel_numbers.format_currency)),

--- a/grow/templates/filters_test.py
+++ b/grow/templates/filters_test.py
@@ -43,14 +43,27 @@ class BuiltinsTestCase(unittest.TestCase):
             filters.hash_value(None, value))
 
     def test_slug_filter(self):
+        slug_filter = filters.slug_filter(self.pod)
         words = 'Foo Bar Baz'
-        self.assertEqual('foo-bar-baz', filters.slug_filter(words))
+        self.assertEqual('foo-bar-baz', slug_filter(words))
 
         words = 'Foo\'s b@z b**'
-        self.assertEqual('foo-s-b-z-b', filters.slug_filter(words))
+        self.assertEqual('foo-s-b-z-b', slug_filter(words))
 
         words = 'Foo: b@z b**'
-        self.assertEqual('foo:b-z-b', filters.slug_filter(words))
+        self.assertEqual('foo-b-z-b', slug_filter(words))
+
+    def test_slug_filter_legacy(self):
+        self.pod.enable(self.pod.FEATURE_OLD_SLUGIFY)
+        slug_filter = filters.slug_filter(self.pod)
+        words = 'Foo Bar Baz'
+        self.assertEqual('foo-bar-baz', slug_filter(words))
+
+        words = 'Foo\'s b@z b**'
+        self.assertEqual('foo-s-b-z-b', slug_filter(words))
+
+        words = 'Foo: b@z b**'
+        self.assertEqual('foo:b-z-b', slug_filter(words))
 
     def test_json(self):
         self.pod.router.add_all()


### PR DESCRIPTION
Changing how slugify works to use the slugify library instead of the built-in method.

Can use the legacy slugify for now by adding this to your `podspec.yaml`:

```
features:
  legacy_slugify: true
```

Fixes #939 