### PR TITLE
Adding the ability to export/import the routes information.

### DIFF
--- a/grow/commands/shared.py
+++ b/grow/commands/shared.py
@@ -133,6 +133,18 @@ def preprocess_option(config):
     return _decorator
 
 
+def routes_file_option(help_text=None):
+    """Option for providing a routes file instead of pulling from content."""
+    if help_text is None:
+        help_text = 'Use routes file to load routes instead of loading from files.'
+
+    def _decorator(func):
+        return click.option(
+            '--routes-file', '--routes_file', type=str, default=None,
+            help=help_text)(func)
+    return _decorator
+
+
 def service_option(func):
     """Option for configuring the transltor service to use."""
     return click.option('--service', '-s', type=str,

--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -33,8 +33,10 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.build')
 @shared.threaded_option(CFG)
 @shared.shards_option
 @shared.shard_option
+@shared.routes_file_option()
 def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
-          locate_untranslated, deployment, threaded, locale, shards, shard):
+          locate_untranslated, deployment, threaded, locale, shards, shard,
+          routes_file):
     """Generates static files and dumps them to a local destination."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     out_dir = out_dir or os.path.join(root, 'build')
@@ -65,6 +67,8 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
             is_partial = bool(pod_paths) or bool(locale)
             if pod_paths:
                 pod.router.add_pod_paths(pod_paths)
+            elif routes_file:
+                pod.router.from_data(pod.read_json(routes_file))
             else:
                 pod.router.add_all()
             if locale:

--- a/grow/commands/subcommands/inspect_routes.py
+++ b/grow/commands/subcommands/inspect_routes.py
@@ -1,5 +1,6 @@
 """Subcommand for displaying all routes of a pod."""
 
+import json
 import os
 import click
 from grow.commands import shared
@@ -12,8 +13,9 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.routes')
 
 
 @click.command(name='routes')
+@shared.routes_file_option('Export route information to a json file.')
 @shared.pod_path_argument
-def inspect_routes(pod_path):
+def inspect_routes(pod_path, routes_file):
     """Lists routes handled by a pod."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     pod = pods.Pod(root, storage=storage.FileStorage)
@@ -21,6 +23,17 @@ def inspect_routes(pod_path):
         out = []
         pod.router.use_simple()
         pod.router.add_all()
+
+        if routes_file:
+            # print pod.router.routes.export()
+            pod.write_file(
+                routes_file,
+                json.dumps(
+                    pod.router.routes.export(), sort_keys=True, indent=2,
+                    separators=(',', ': ')))
+            print 'Exported routes to file: {}'.format(routes_file)
+            return pod
+
         for path, node, _ in pod.router.routes.nodes:
             out.append(u'{} [{}]\n    {}\n'.format(path, node.kind, node.meta))
         click.echo_via_pager('\n'.join(out))

--- a/grow/commands/subcommands/stage.py
+++ b/grow/commands/subcommands/stage.py
@@ -31,9 +31,10 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.stage')
 @shared.preprocess_option(CFG)
 @shared.threaded_option(CFG)
 @shared.work_dir_option
+@shared.routes_file_option()
 @click.pass_context
 def stage(context, pod_path, remote, preprocess, subdomain, api_key,
-          force_untranslated, threaded, work_dir):
+          force_untranslated, threaded, work_dir, routes_file):
     """Stages a build on a WebReview server."""
     root = os.path.abspath(os.path.join(os.getcwd(), pod_path))
     auth = context.parent.params.get('auth')
@@ -59,7 +60,10 @@ def stage(context, pod_path, remote, preprocess, subdomain, api_key,
                 pod, source_dir=work_dir, use_threading=threaded)
             repo = utils.get_git_repo(pod.root)
             pod.router.use_simple()
-            pod.router.add_all()
+            if routes_file:
+                pod.router.from_data(pod.read_json(routes_file))
+            else:
+                pod.router.add_all()
             paths = pod.router.routes.paths
             stats_obj = stats.Stats(pod, paths=paths)
             deployment.deploy(content_generator, stats=stats_obj, repo=repo,

--- a/grow/routing/path_filter.py
+++ b/grow/routing/path_filter.py
@@ -62,6 +62,13 @@ class PathFilter(object):
         """Add a new included pattern."""
         self._included.append(re.compile(raw_pattern))
 
+    def export(self):
+        """Export for serialization."""
+        return {
+            'ignored': [item.pattern for item in self._ignored],
+            'included': [item.pattern for item in self._included],
+        }
+
     def is_valid(self, path):
         """Tests if the path is valid according to the known filters."""
         if self._is_ignored(path):

--- a/grow/routing/routes.py
+++ b/grow/routing/routes.py
@@ -74,6 +74,19 @@ class Routes(object):
             return
         self._root.add(path, value, options=options)
 
+    def export(self):
+        """Export the routes into a serializable format."""
+        routing_info = {}
+        for path, value, options in self.nodes:
+            value = value.export() if hasattr(value, 'export') else value
+            if options:
+                print options
+            routing_info[path] = {
+                'value': value,
+                'options': options,
+            }
+        return routing_info
+
     def filter(self, func):
         """Filters out the nodes that do not match the filter."""
         if not func:


### PR DESCRIPTION
This allows for the routes to be generated and stored in a json file then for later commands to use the routes file to load routes instead of needing to regenerate all of the routing info.

Especially used for sharding processes as larger sites can take several minutes to load routing information.