### PR TITLE
Updating the yaml parse to separate into a base and normal loader.

### DIFF
--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -280,8 +280,8 @@ def make_base_yaml_loader(pod, locale=None, untag_params=None,
                 file_cache.add(pod_path, contents)
             return contents
 
-        @staticmethod
-        def read_string(path):
+        @classmethod
+        def read_string(cls, path):
             if '.' not in path:
                 return None
             main, reference = path.split('.', 1)
@@ -289,17 +289,17 @@ def make_base_yaml_loader(pod, locale=None, untag_params=None,
             tracking_func(path)
             if reference:
                 data = structures.DeepReferenceDict(
-                    self.read_yaml(path, locale=self.loader_locale()))
+                    cls.read_yaml(path, locale=cls.loader_locale()))
                 try:
                     allow_draft = pod.podspec.fields.get('strings', {}).get('allow_draft')
                     if allow_draft is False and data.get(DRAFT_KEY):
                         raise DraftStringError('Encountered string in draft -> {}?{}'.format(path, reference))
                     value = data[reference]
                     if value is None:
-                        if self.pod_path():
+                        if cls.pod_path():
                             pod.logger.warning(
                                 'Missing {}.{} in {}'.format(
-                                    main, reference, self.pod_path()))
+                                    main, reference, cls.pod_path()))
                         pod.logger.warning(
                             'Missing {}.{}'.format(main, reference))
                     return value

--- a/grow/common/utils_test.py
+++ b/grow/common/utils_test.py
@@ -129,6 +129,14 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(expected_deep_yaml, result['deep'])
         self.assertEqual(None, result['unfathomable'])
 
+    def test_parse_yaml_strings(self):
+        """Parsing using strings constructor."""
+        pod = testing.create_test_pod()
+        content = pod.read_file('/data/string.yaml')
+        result = utils.parse_yaml(content, pod=pod)
+        self.assertEqual('Sun', result['sun'])
+        self.assertEqual('Mars', result['mars'])
+
     def test_process_google_comments(self):
         # Google comment link.
         raw = '<div><a id="cmnt" href="https://grow.io/">Link</a></div>'

--- a/grow/common/yaml_utils.py
+++ b/grow/common/yaml_utils.py
@@ -79,6 +79,8 @@ PlainTextYamlLoader.add_constructor(
 PlainTextYamlLoader.add_constructor(
     u'!g.static', PlainTextYamlLoader.construct_plaintext)
 PlainTextYamlLoader.add_constructor(
+    u'!g.string', PlainTextYamlLoader.construct_plaintext)
+PlainTextYamlLoader.add_constructor(
     u'!g.url', PlainTextYamlLoader.construct_plaintext)
 PlainTextYamlLoader.add_constructor(
     u'!g.yaml', PlainTextYamlLoader.construct_plaintext)

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -21,7 +21,8 @@ from grow.common import yaml_utils
 
 ROUTES_FILENAME = '_blueprint.yaml'
 COLLECTION_META_KEYS = ('$path', '$localization', '$view')
-COLLECTION_BLUEPRINT_KEYS = ('$path', '$localization', '$view', 'path', 'localization', 'view')
+COLLECTION_BLUEPRINT_KEYS = (
+    '$path', '$localization', '$view', 'path', 'localization', 'view')
 
 
 class Error(Exception):
@@ -66,10 +67,17 @@ class RoutesData(object):
 
         for key, value in raw_data.iteritems():
             if key in COLLECTION_META_KEYS or key.startswith(tagged_keys):
-                data[key.lstrip('$')] = value
+                normal_key = key.lstrip('$')
+                if 'path' in key:
+                    collection_path = self.blueprint.get(
+                        key, self.blueprint.get(normal_key))
+                    # Skip the paths that are the same as the collection.
+                    if collection_path == value:
+                        continue
+                data[normal_key] = value
 
         if data:
-            self.paths[doc.collection_path[1:]] = data
+            self.paths[doc.collection_sub_path[1:]] = data
 
     def write_routes(self, pod, collection):
         """Write the converted routes to the configuration file."""

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -59,7 +59,16 @@ class RoutesData(object):
 
     def extract_doc(self, doc):
         """Extract the meta information from the doc to use for the routes."""
-        raw_data = doc.format.front_matter.raw_data
+        if doc.pod_path.endswith('.yaml'):
+            raw_data = yaml.load(
+                doc.pod.read_file(doc.pod_path), Loader=yaml_utils.PlainTextYamlLoader)
+        else:
+            raw_data = doc.format.front_matter.raw_data
+
+        if not raw_data:
+            print 'No raw data found for document: {}'.format(doc.pod_path)
+            return
+
         data = collections.OrderedDict()
 
         tagged_keys = tuple(['{}@'.format(key)

--- a/grow/testing/testdata/pod/content/strings/stellar.yaml
+++ b/grow/testing/testdata/pod/content/strings/stellar.yaml
@@ -1,0 +1,4 @@
+sun: Sun
+moon: Moon
+planets:
+  mars: Mars

--- a/grow/testing/testdata/pod/data/string.yaml
+++ b/grow/testing/testdata/pod/data/string.yaml
@@ -1,0 +1,2 @@
+sun: !g.string stellar.sun
+mars: !g.string stellar.planets.mars


### PR DESCRIPTION
Certain cases for the yaml loading should use a subset of the yaml constructors. Specifically ones that don't access collections and documents to prevent circular references.

This change allows for yaml to be loaded with some of the constructors (like `!g.yaml`) but not allow for using doc or static constructors which blow up due to circular references when loading thing such as collection blueprints.

This PR also fixes some issues with the collection sub path in the conversion script and updates the collection to use the simpler yaml loading to allow for yaml constructors in the blueprint.