### PR TITLE
Preloading support for cached routes.

### DIFF
--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -7,6 +7,7 @@ from grow.common import rc_config
 from grow.common import utils
 from grow.deployments import stats
 from grow.deployments.destinations import local as local_destination
+from grow.performance import docs_loader
 from grow.pods import pods
 from grow.rendering import renderer
 from grow import storage
@@ -73,10 +74,16 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
                 pod.router.add_all()
             if locale:
                 pod.router.filter('whitelist', locales=list(locale))
+
             # Shard the routes when using sharding.
             if shards and shard:
                 is_partial = True
                 pod.router.shard(shards, shard)
+
+            # Preload the documents used by the paths after filtering.
+            docs_loader.DocsLoader.load_from_routes(pod, pod.router.routes)
+            return
+
             paths = pod.router.routes.paths
             content_generator = renderer.Renderer.rendered_docs(
                 pod, pod.router.routes, use_threading=threaded)

--- a/grow/commands/subcommands/build.py
+++ b/grow/commands/subcommands/build.py
@@ -82,7 +82,6 @@ def build(pod_path, out_dir, preprocess, clear_cache, pod_paths,
 
             # Preload the documents used by the paths after filtering.
             docs_loader.DocsLoader.load_from_routes(pod, pod.router.routes)
-            return
 
             paths = pod.router.routes.paths
             content_generator = renderer.Renderer.rendered_docs(

--- a/grow/commands/subcommands/deploy.py
+++ b/grow/commands/subcommands/deploy.py
@@ -8,6 +8,7 @@ from grow.common import rc_config
 from grow.common import utils
 from grow.deployments import stats
 from grow.deployments.destinations import base
+from grow.performance import docs_loader
 from grow.pods import pods
 from grow.rendering import renderer
 from grow import storage
@@ -81,10 +82,15 @@ def deploy(context, deployment_name, pod_path, preprocess, confirm, test,
                 pod.router.filter(
                     build_filter.type, collection_paths=build_filter.collections,
                     paths=build_filter.paths, locales=build_filter.locales)
+
             # Shard the routes when using sharding.
             if shards and shard:
                 is_partial = True
                 pod.router.shard(shards, shard)
+
+            # Preload the documents used by the paths after filtering.
+            docs_loader.DocsLoader.load_from_routes(pod, pod.router.routes)
+
             paths = pod.router.routes.paths
             stats_obj = stats.Stats(pod, paths=paths)
             deployment.deploy(

--- a/grow/commands/subcommands/stage.py
+++ b/grow/commands/subcommands/stage.py
@@ -8,6 +8,7 @@ from grow.common import utils
 from grow.deployments import stats
 from grow.deployments.destinations import base
 from grow.deployments.destinations import webreview_destination
+from grow.performance import docs_loader
 from grow.pods import pods
 from grow.rendering import renderer
 from grow import storage
@@ -64,6 +65,10 @@ def stage(context, pod_path, remote, preprocess, subdomain, api_key,
                 pod.router.from_data(pod.read_json(routes_file))
             else:
                 pod.router.add_all()
+
+            # Preload the documents used by the paths after filtering.
+            docs_loader.DocsLoader.load_from_routes(pod, pod.router.routes)
+
             paths = pod.router.routes.paths
             stats_obj = stats.Stats(pod, paths=paths)
             deployment.deploy(content_generator, stats=stats_obj, repo=repo,

--- a/grow/extensions/core/routes_extension.py
+++ b/grow/extensions/core/routes_extension.py
@@ -108,7 +108,7 @@ class RoutesDevFileChangeHook(hooks.DevFileChangeHook):
                 pod.podcache.collection_cache.remove_document_locales(doc)
 
             # Force load the docs and fix locales.
-            docs_loader.DocsLoader.load(base_docs, ignore_errors=True)
+            docs_loader.DocsLoader.load(pod, base_docs, ignore_errors=True)
             docs_loader.DocsLoader.fix_default_locale(
                 pod, base_docs, ignore_errors=True)
 

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -57,8 +57,7 @@ class Router(object):
 
     def add_all(self, concrete=True, use_cache=True):
         """Add all documents and static content."""
-
-        if not use_cache:
+        if use_cache:
             unchanged_pod_paths = self.from_cache(concrete=concrete)
         else:
             unchanged_pod_paths = []

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -36,12 +36,12 @@ class Router(object):
 
     def _preload_and_expand(self, docs, expand=True):
         # Force preload the docs.
-        docs_loader.DocsLoader.load(docs)
+        docs_loader.DocsLoader.load(self.pod, docs)
         docs_loader.DocsLoader.fix_default_locale(self.pod, docs)
         if expand:
             # Will need all of the docs, so expand them out and preload.
             docs = docs_loader.DocsLoader.expand_locales(self.pod, docs)
-            docs_loader.DocsLoader.load(docs)
+            docs_loader.DocsLoader.load(self.pod, docs)
         return docs
 
     @property


### PR DESCRIPTION
When using cached routing the preloader doesn't use the full list of documents to preload since it only loads the changed docs. This change waits until all the routes are determined then calls the proloader with only the docs that exist in the routes.