### PR TITLE
Ignoring the fingerprinted static files when loading from cache.

### DIFF
--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -405,6 +405,10 @@ class Router(object):
             if route_info.hashed != self.pod.hash_file(route_info.pod_path):
                 continue
 
+            # Ignore the fingerprinted files.
+            if 'fingerprinted' in route_info.meta and route_info.meta['fingerprinted']:
+                continue
+
             unchanged_pod_paths.add(route_info.pod_path)
             self.routes.add(key, route_info, options=item['options'])
 


### PR DESCRIPTION
Fingerprinted files get updated by the watcher which causes a duplicate error when the js/css building is done.

Fixes #951