### PR TITLE
Add logging message to indicate which email address is used to authorize oauth requests.

### DIFF
--- a/grow/common/oauth.py
+++ b/grow/common/oauth.py
@@ -29,6 +29,7 @@ REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 DEFAULT_STORAGE_KEY = 'Grow SDK'
 BROWSER_API_KEY = 'AIzaSyDCb_WtWJnlLPdL8IGLvcVhXAjaBHbRY5E'
 
+_LAST_LOGGED_EMAIL = None
 _CLEARED_AUTH_KEYS = {}
 
 DEFAULT_AUTH_KEY_FILE = 'auth-key.json'
@@ -83,6 +84,11 @@ def get_or_create_credentials(scope, storage_key=DEFAULT_STORAGE_KEY):
         credentials = tools.run_flow(flow, storage, flags)
         # run_flow changes the logging level, so change it back.
         logging.getLogger().setLevel(getattr(logging, 'INFO'))
+    # Avoid logspam by logging the email address only once.
+    if hasattr(credentials, 'id_token'):
+        email = credentials.id_token['email']
+        if _LAST_LOGGED_EMAIL != email:
+            logging.info('Authorizing using -> {}'.format(email))
     return credentials
 
 

--- a/grow/common/oauth.py
+++ b/grow/common/oauth.py
@@ -87,6 +87,7 @@ def get_or_create_credentials(scope, storage_key=DEFAULT_STORAGE_KEY):
     # Avoid logspam by logging the email address only once.
     if hasattr(credentials, 'id_token'):
         email = credentials.id_token['email']
+        # pylint: disable=used-before-assignment
         if _LAST_LOGGED_EMAIL != email:
             logging.info('Authorizing using -> {}'.format(email))
             _LAST_LOGGED_EMAIL = email

--- a/grow/common/oauth.py
+++ b/grow/common/oauth.py
@@ -89,6 +89,7 @@ def get_or_create_credentials(scope, storage_key=DEFAULT_STORAGE_KEY):
         email = credentials.id_token['email']
         if _LAST_LOGGED_EMAIL != email:
             logging.info('Authorizing using -> {}'.format(email))
+            _LAST_LOGGED_EMAIL = email
     return credentials
 
 


### PR DESCRIPTION
Creates output like:

$ ~/git/grow/scripts/grow preprocess -p kintaro
Authorizing using -> jeremydw@gmail.com
Refreshing access_token
[12:12:22] Saved -> /content/BrandPage/samples.yaml
[12:12:22] Schema -> /content/BrandPage/_schema.yaml