### PR TITLE
Updating the local `/_grow/` handlers to work when the routes reset.

### DIFF
--- a/grow/server/handlers.py
+++ b/grow/server/handlers.py
@@ -1,0 +1,78 @@
+"""Response handlers for dev server."""
+
+import mimetypes
+import webob
+from werkzeug import wrappers
+from grow.pods import ui
+
+
+class Response(webob.Response):
+    default_conditional_response = True
+
+
+def serve_console(pod, _request, _matched, **_kwargs):
+    """Serve the default console page."""
+    kwargs = {'pod': pod}
+    env = ui.create_jinja_env()
+    template = env.get_template('/views/base.html')
+    content = template.render(kwargs)
+    response = wrappers.Response(content)
+    response.headers['Content-Type'] = 'text/html'
+    return response
+
+
+def serve_editor(pod, _request, matched, meta=None, **_kwargs):
+    """Serve the default console page."""
+    kwargs = {
+        'pod': pod,
+        'meta': meta,
+        'path': matched.params['path'] if 'path' in matched.params else '',
+    }
+    env = ui.create_jinja_env()
+    template = env.get_template('/views/editor.html')
+    content = template.render(kwargs)
+    response = wrappers.Response(content)
+    response.headers['Content-Type'] = 'text/html'
+    return response
+
+
+def serve_pod(pod, request, matched, **_kwargs):
+    """Serve pod contents using the new routing."""
+    controller = pod.router.get_render_controller(
+        request.path, matched.value, params=matched.params)
+    response = None
+    headers = controller.get_http_headers()
+    if 'X-AppEngine-BlobKey' in headers:
+        return Response(headers=headers)
+    jinja_env = pod.render_pool.get_jinja_env(
+        controller.doc.locale) if controller.use_jinja else None
+    rendered_document = controller.render(jinja_env=jinja_env)
+    content = rendered_document.read()
+    response = Response(body=content)
+    response.headers.update(headers)
+
+    if pod.podcache.is_dirty:
+        pod.podcache.write()
+
+    return response
+
+
+def serve_ui_tool(pod, _request, values, **_kwargs):
+    tool_path = 'node_modules/{}'.format(values.get('tool'))
+    response = wrappers.Response(pod.read_file(tool_path))
+    guessed_type = mimetypes.guess_type(tool_path)
+    mime_type = guessed_type[0] or 'text/plain'
+    response.headers['Content-Type'] = mime_type
+    return response
+
+
+def serve_run_preprocessor(pod, _request, values):
+    name = values.get('name')
+    if name:
+        pod.preprocess([name])
+        out = 'Finished preprocessor run -> {}'.format(name)
+    else:
+        out = 'No preprocessor found.'
+    response = wrappers.Response(out)
+    response.headers['Content-Type'] = 'text/plain'
+    return response

--- a/grow/server/handlers.py
+++ b/grow/server/handlers.py
@@ -6,6 +6,10 @@ from werkzeug import wrappers
 from grow.pods import ui
 
 
+class Request(webob.Request):
+    pass
+
+
 class Response(webob.Response):
     default_conditional_response = True
 
@@ -37,7 +41,7 @@ def serve_editor(pod, _request, matched, meta=None, **_kwargs):
 
 
 def serve_pod(pod, request, matched, **_kwargs):
-    """Serve pod contents using the new routing."""
+    """Serve pod contents using the routing."""
     controller = pod.router.get_render_controller(
         request.path, matched.value, params=matched.params)
     response = None

--- a/grow/server/main.py
+++ b/grow/server/main.py
@@ -1,21 +1,12 @@
 """Grow local development server."""
 
-import logging
 import os
-import re
-import sys
-import traceback
 import urllib
-import jinja2
-# NOTE: exc imported directly, webob.exc doesn't work when frozen.
-from webob import exc as webob_exc
-from werkzeug import wrappers
 from werkzeug import serving
 from werkzeug import wsgi
 from grow.common import config
 from grow.common import utils
 from grow.pods import errors
-from grow.pods import ui
 from grow.server import handlers
 
 
@@ -37,7 +28,7 @@ class PodServer(object):
             return self.wsgi_app(environ, start_response)
         except Exception as e:
             request = handlers.Request(environ)
-            response = self.handle_exception(request, e)
+            response = handlers.serve_exception(self.pod, request, e)
             return response(environ, start_response)
 
     def __init__(self, pod, host, port, debug=False):
@@ -73,53 +64,6 @@ class PodServer(object):
                     self.pod, request, matched, meta=handler_meta)
             return handlers.serve_console(self.pod, request, matched)
         return handlers.serve_pod(self.pod, request, matched)
-
-    def handle_exception(self, request, exc):
-        self.debug = True
-        log = logging.exception if self.debug else self.pod.logger.error
-        if isinstance(exc, webob_exc.HTTPException):
-            status = exc.status_int
-            log('{}: {}'.format(status, request.path))
-        elif isinstance(exc, errors.RouteNotFoundError):
-            status = 404
-            log('{}: {}'.format(status, request.path))
-        else:
-            status = 500
-            log('{}: {} - {}'.format(status, request.path, exc))
-        env = ui.create_jinja_env()
-        template = env.get_template('/views/error.html')
-        if (isinstance(exc, errors.BuildError)):
-            tb = exc.traceback
-        else:
-            unused_error_type, unused_value, tb = sys.exc_info()
-        formatted_traceback = [
-            re.sub('^  ', '', line)
-            for line in traceback.format_tb(tb)]
-        formatted_traceback = '\n'.join(formatted_traceback)
-        kwargs = {
-            'exception': exc,
-            'is_web_exception': isinstance(exc, webob_exc.HTTPException),
-            'pod': self.pod,
-            'status': status,
-            'traceback': formatted_traceback,
-        }
-        try:
-            home_doc = self.pod.get_home_doc()
-            if home_doc:
-                kwargs['home_url'] = home_doc.url.path
-        except:
-            pass
-        if (isinstance(exc, errors.BuildError)):
-            kwargs['build_error'] = exc.exception
-        if (isinstance(exc, errors.BuildError)
-                and isinstance(exc.exception, jinja2.TemplateSyntaxError)):
-            kwargs['template_exception'] = exc.exception
-        elif isinstance(exc, jinja2.TemplateSyntaxError):
-            kwargs['template_exception'] = exc
-        content = template.render(**kwargs)
-        response = wrappers.Response(content, status=status)
-        response.headers['Content-Type'] = 'text/html'
-        return response
 
     def wsgi_app(self, environ, start_response):
         request = handlers.Request(environ)

--- a/grow/server/main.py
+++ b/grow/server/main.py
@@ -7,11 +7,8 @@ import sys
 import traceback
 import urllib
 import jinja2
-import webob
 # NOTE: exc imported directly, webob.exc doesn't work when frozen.
 from webob import exc as webob_exc
-from werkzeug import routing
-from werkzeug import utils as werkzeug_utils
 from werkzeug import wrappers
 from werkzeug import serving
 from werkzeug import wsgi
@@ -20,10 +17,6 @@ from grow.common import utils
 from grow.pods import errors
 from grow.pods import ui
 from grow.server import handlers
-
-
-class Request(webob.Request):
-    pass
 
 
 # Use grow's logger instead of werkzeug's default.
@@ -43,7 +36,7 @@ class PodServer(object):
         try:
             return self.wsgi_app(environ, start_response)
         except Exception as e:
-            request = Request(environ)
+            request = handlers.Request(environ)
             response = self.handle_exception(request, e)
             return response(environ, start_response)
 
@@ -129,7 +122,7 @@ class PodServer(object):
         return response
 
     def wsgi_app(self, environ, start_response):
-        request = Request(environ)
+        request = handlers.Request(environ)
         response = self.dispatch_request(request)
         return response(environ, start_response)
 

--- a/grow/server/manager.py
+++ b/grow/server/manager.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from grow.common import colors
 from grow.common import timer
+from grow.documents import document
 from grow.preprocessors import file_watchers
 from grow.sdk import updater
 from grow.server import main as main_lib
@@ -41,7 +42,7 @@ class CallbackHTTPServer(serving.ThreadedWSGIServer):
 
 def print_server_ready_message(pod, host, port):
     home_doc = pod.get_home_doc()
-    root_path = home_doc.url.path if home_doc else '/'
+    root_path = home_doc.url.path if home_doc and home_doc.exists else '/'
     url = 'http://{}:{}{}'.format(host, port, root_path)
     logging.info('Pod: '.rjust(20) + pod.root)
     logging.info('Address: '.rjust(20) + url)


### PR DESCRIPTION
When the routes are reset then the handlers are also lost for the `/_grow/` pages are lost. This change consolidates the handlers and triggers the dev handler hook to recreate the built-in dev routes.

Fixes #855