### PR TITLE
Adding the ability to skip install for npm and extensions

### DIFF
--- a/grow/commands/subcommands/install.py
+++ b/grow/commands/subcommands/install.py
@@ -21,7 +21,7 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.install')
                    'If omitted, Grow will attempt to detect whether there is a '
                    'known Gerrit host amongst the remotes in your repository.')
 @click.option('--force', '-f', default=False, is_flag=True,
-             help='Whether to overwrite existing files.')
+             help='Whether to force install even when no changes found.')
 def install(pod_path, gerrit, force):
     """Checks whether the pod depends on npm, bower, and gulp and installs them
     if necessary. Then, runs install commands. Also optionally installs the

--- a/grow/commands/subcommands/install.py
+++ b/grow/commands/subcommands/install.py
@@ -20,7 +20,9 @@ CFG = rc_config.RC_CONFIG.prefixed('grow.install')
               help='Whether to install the Gerrit Code Review commit hook. '
                    'If omitted, Grow will attempt to detect whether there is a '
                    'known Gerrit host amongst the remotes in your repository.')
-def install(pod_path, gerrit):
+@click.option('--force', '-f', default=False, is_flag=True,
+             help='Whether to overwrite existing files.')
+def install(pod_path, gerrit, force):
     """Checks whether the pod depends on npm, bower, and gulp and installs them
     if necessary. Then, runs install commands. Also optionally installs the
     Gerrit Code Review commit hook."""
@@ -30,6 +32,7 @@ def install(pod_path, gerrit):
     with pod.profile.timer('grow_install'):
         config = base_config.BaseConfig()
         config.set('gerrit', gerrit)
+        config.set('force', force)
         built_in_installers = []
         for installer_class in installers.BUILT_IN_INSTALLERS:
             built_in_installers.append(installer_class(pod, config))

--- a/grow/sdk/installers/extensions_installer.py
+++ b/grow/sdk/installers/extensions_installer.py
@@ -4,10 +4,17 @@ import subprocess
 from grow.sdk.installers import base_installer
 
 
+INSTALL_HASH_FILE_NAME = 'install-hash.txt'
+
+
 class ExtensionsInstaller(base_installer.BaseInstaller):
     """Grow extensions installer."""
 
     KIND = 'extensions'
+
+    def _generate_hashes(self):
+        """Create hash string based on the package and lock files."""
+        return self.pod.hash_file(self.extensions_filename)
 
     @property
     def post_install_messages(self):
@@ -15,9 +22,32 @@ class ExtensionsInstaller(base_installer.BaseInstaller):
         return ['Finished: Extensions -> {}/'.format(self.pod.extensions_dir)]
 
     @property
+    def extensions_filename(self):
+        """Filename for the install hash."""
+        return '/{}'.format(self.pod.FILE_EXTENSIONS)
+
+    @property
+    def install_hash_filename(self):
+        """Filename for the install hash."""
+        return '/{}/{}'.format(self.pod.extensions_dir, INSTALL_HASH_FILE_NAME)
+
+    @property
     def should_run(self):
         """Should the installer run?"""
-        return self.pod.file_exists('/{}'.format(self.pod.FILE_EXTENSIONS))
+        if not self.pod.file_exists(self.extensions_filename):
+            return False
+
+        if self.config.get('force', None):
+            return True
+
+        if self.pod.file_exists(self.install_hash_filename):
+            existing_hash = self.pod.read_file(self.install_hash_filename)
+            current_hash = self._generate_hashes()
+            if existing_hash == current_hash:
+                self.pod.logger.info('Skipping extensions install since no changes detected.')
+                self.pod.logger.info('   Use `grow install -f` to force install.')
+                return False
+        return True
 
     def check_prerequisites(self):
         """Check if required prerequisites are installed or available."""
@@ -40,6 +70,7 @@ class ExtensionsInstaller(base_installer.BaseInstaller):
             install_command, **self.subprocess_args(shell=True))
         code = process.wait()
         if not code:
+            self.pod.write_file(self.install_hash_filename, self._generate_hashes())
             return
         raise base_installer.InstallError(
             'There was an error running `{}`.'.format(install_command))

--- a/grow/sdk/installers/extensions_installer.py
+++ b/grow/sdk/installers/extensions_installer.py
@@ -14,6 +14,8 @@ class ExtensionsInstaller(base_installer.BaseInstaller):
 
     def _generate_hashes(self):
         """Create hash string based on the package and lock files."""
+        if not self.pod.file_exists(self.extensions_filename):
+            return ''
         return self.pod.hash_file(self.extensions_filename)
 
     @property

--- a/grow/sdk/installers/npm_installer.py
+++ b/grow/sdk/installers/npm_installer.py
@@ -5,6 +5,12 @@ from grow.sdk import sdk_utils
 from grow.sdk.installers import base_installer
 
 
+INSTALL_HASH_FILE = '/node_modules/install-hash.txt'
+NPM_LOCK_FILE = '/package-lock.json'
+PACKAGE_FILE = '/package.json'
+YARN_LOCK_FILE = '/yarn.lock'
+
+
 class NpmInstaller(base_installer.BaseInstaller):
     """Grow npm and yarn installer."""
 
@@ -24,13 +30,26 @@ class NpmInstaller(base_installer.BaseInstaller):
     @property
     def should_run(self):
         """Should the installer run?"""
-        return self.pod.file_exists('/package.json')
+        if not self.pod.file_exists(PACKAGE_FILE):
+            return False
+
+        if self.config.get('force', None):
+            return True
+
+        if self.pod.file_exists(INSTALL_HASH_FILE):
+            existing_hash = self.pod.read_file(INSTALL_HASH_FILE)
+            current_hash = self._generate_hashes()
+            if existing_hash == current_hash:
+                self.pod.logger.info('Skipping npm/yarn install since no changes detected.')
+                self.pod.logger.info('   Use `grow install -f` to force install.')
+                return False
+        return True
 
     @property
     def using_yarn(self):
         """Is the pod using yarn?"""
         if self._using_yarn is None:
-            self._using_yarn = self.pod.file_exists('/yarn.lock')
+            self._using_yarn = self.pod.file_exists(YARN_LOCK_FILE)
         return self._using_yarn
 
     def _check_prerequisites_npm(self):
@@ -65,12 +84,22 @@ class NpmInstaller(base_installer.BaseInstaller):
             raise base_installer.MissingPrerequisiteError(
                 'The `yarn` command was not found.', install_commands=install_commands)
 
+    def _generate_hashes(self):
+        """Create hash string based on the package and lock files."""
+        hash_string = self.pod.hash_file(PACKAGE_FILE)
+        if self.pod.file_exists(YARN_LOCK_FILE):
+            hash_string = '{} {}'.format(hash_string, self.pod.hash_file(YARN_LOCK_FILE))
+        if self.pod.file_exists(NPM_LOCK_FILE):
+            hash_string = '{} {}'.format(hash_string, self.pod.hash_file(NPM_LOCK_FILE))
+        return hash_string
+
     def _install_npm(self):
         """Install dependencies using npm."""
         install_command = self._nvm_command('npm install')
         process = subprocess.Popen(install_command, **self.subprocess_args(shell=True))
         code = process.wait()
         if not code:
+            self.pod.write_file(INSTALL_HASH_FILE, self._generate_hashes())
             return
         raise base_installer.InstallError(
             'There was an error running `npm install`.')
@@ -81,6 +110,7 @@ class NpmInstaller(base_installer.BaseInstaller):
         process = subprocess.Popen(install_command, **self.subprocess_args(shell=True))
         code = process.wait()
         if not code:
+            self.pod.write_file(INSTALL_HASH_FILE, self._generate_hashes())
             return
         raise base_installer.InstallError(
             'There was an error running `yarn install`.')

--- a/grow/sdk/installers/npm_installer.py
+++ b/grow/sdk/installers/npm_installer.py
@@ -86,7 +86,9 @@ class NpmInstaller(base_installer.BaseInstaller):
 
     def _generate_hashes(self):
         """Create hash string based on the package and lock files."""
-        hash_string = self.pod.hash_file(PACKAGE_FILE)
+        hash_string = ''
+        if self.pod.file_exists(PACKAGE_FILE):
+            hash_string = self.pod.hash_file(PACKAGE_FILE)
         if self.pod.file_exists(YARN_LOCK_FILE):
             hash_string = '{} {}'.format(hash_string, self.pod.hash_file(YARN_LOCK_FILE))
         if self.pod.file_exists(NPM_LOCK_FILE):


### PR DESCRIPTION
Adds a hash file when the install is completed to the directories.

When CI builds restore caches, the install command should find the hash file and use it to determine if there is a need to run the install.

Fixes #978