### PR TITLE
Add {{request}} to dev server renderer

### DIFF
--- a/grow/rendering/render_controller.py
+++ b/grow/rendering/render_controller.py
@@ -89,7 +89,7 @@ class RenderController(object):
         """Load the pod content from file system."""
         raise NotImplementedError
 
-    def render(self, jinja_env):
+    def render(self, jinja_env, request=None):
         """Render the pod content."""
         raise NotImplementedError
 
@@ -178,7 +178,7 @@ class RenderDocumentController(RenderController):
             exception.exception = err
             raise exception
 
-    def render(self, jinja_env=None):
+    def render(self, jinja_env=None, request=None):
         """Render the document using the render pool."""
         timer = self.pod.profile.timer(
             'RenderDocumentController.render',
@@ -218,6 +218,7 @@ class RenderDocumentController(RenderController):
 
             rendered_content = template.render({
                 'doc': doc,
+                'request': request,
                 'env': self.pod.env,
                 'podspec': self.pod.podspec,
                 '_track_dependency': track_dependency,
@@ -282,7 +283,7 @@ class RenderErrorController(RenderController):
             exception.exception = err
             raise exception
 
-    def render(self, jinja_env=None):
+    def render(self, jinja_env=None, request=None):
         """Render the document using the render pool."""
         timer = self.pod.profile.timer(
             'RenderErrorController.render',
@@ -366,7 +367,7 @@ class RenderSitemapController(RenderController):
             exception.exception = err
             raise exception
 
-    def render(self, jinja_env=None):
+    def render(self, jinja_env=None, request=None):
         """Render the document using the render pool."""
         timer = self.pod.profile.timer(
             'RenderSitemapController.render',
@@ -496,7 +497,7 @@ class RenderStaticDocumentController(RenderController):
         timer.stop_timer()
         return rendered_doc
 
-    def render(self, jinja_env=None):
+    def render(self, jinja_env=None, request=None):
         """Read the static file."""
         timer = self.pod.profile.timer(
             'RenderStaticDocumentController.render', label=self.serving_path,

--- a/grow/server/handlers.py
+++ b/grow/server/handlers.py
@@ -105,7 +105,7 @@ def serve_pod(pod, request, matched, **_kwargs):
         return Response(headers=headers)
     jinja_env = pod.render_pool.get_jinja_env(
         controller.doc.locale) if controller.use_jinja else None
-    rendered_document = controller.render(jinja_env=jinja_env)
+    rendered_document = controller.render(jinja_env=jinja_env, request=request)
     content = rendered_document.read()
     response = Response(body=content)
     response.headers.update(headers)


### PR DESCRIPTION
I know this is a bit controversial but it would be extremely handy for developer quality of life. For example, on some large websites we want to build in debugging features (locally) that render different content depending on the request. (i.e. `?debug=foo`). I looked into a way to add an extension to do this but extensions wouldn't have access to the WebOb request object.

This PR adds `{{request}}` to the environment globals, and it'll be `None` if rendering inside a build. I can use `{{request.GET.debug}}` to get the value of `?debug` from the query string.