### PR TITLE
Ensure that the collection exists, or try to get one that does.

### DIFF
--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -76,7 +76,7 @@ class Document(object):
         self.basename = Document._clean_basename(pod_path)
         self.base, self.ext = os.path.splitext(self.basename)
         self.pod = _pod
-        self.collection = _collection
+        self.collection = self._collection_exists(_collection)
         self._locale = utils.SENTINEL
 
     def __ne__(self, other):
@@ -91,6 +91,16 @@ class Document(object):
     def _clean_basename(cls, pod_path):
         base_pod_path = cls._locale_paths(pod_path)[-1]
         return os.path.basename(base_pod_path)
+
+    @staticmethod
+    def _collection_exists(collection):
+        orig_collection = collection
+        while not collection.exists:
+            collection = collection.parent
+            if not collection:
+                collection = orig_collection
+                break
+        return collection
 
     @classmethod
     def _locale_paths(cls, pod_path):


### PR DESCRIPTION
Fixes a problem where the collection is not validated as existing before being used.

This can cause issues with document that don't define paths, but the collection path used doesn't exist because it is a sub directory.