### PR TITLE
Adjusting to allow collection routing with an empty object.

### DIFF
--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -177,7 +177,7 @@ class Collection(object):
         ])
 
         # Enable the separate_routing feature if there are routes specified.
-        if self.yaml.get('routes', {}):
+        if self.yaml.get('routes', None) is not None:
             coll_features.enable(self.FEATURE_SEPARATE_ROUTING)
 
         return coll_features

--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -177,7 +177,7 @@ class Collection(object):
         ])
 
         # Enable the separate_routing feature if there are routes specified.
-        if self.yaml.get('routes', None) is not None:
+        if self.yaml.get('routes') is not None:
             coll_features.enable(self.FEATURE_SEPARATE_ROUTING)
 
         return coll_features


### PR DESCRIPTION
Previously it required at least one customized route data to pass the check.