### PR TITLE
Fixing the usage of the doc when loading to not need to read the file.

### DIFF
--- a/grow/rendering/render_controller.py
+++ b/grow/rendering/render_controller.py
@@ -140,9 +140,9 @@ class RenderDocumentController(RenderController):
     @property
     def pod_path(self):
         """Locale to use for rendering."""
-        if 'locale' in self.route_info.meta:
-            return self.route_info.meta['locale']
-        return self.doc.locale if self.doc else None
+        if 'pod_path' in self.route_info.meta:
+            return self.route_info.meta['pod_path']
+        return self.doc.pod_path if self.doc else None
 
     @property
     def suffix(self):

--- a/grow/rendering/render_controller.py
+++ b/grow/rendering/render_controller.py
@@ -128,12 +128,21 @@ class RenderDocumentController(RenderController):
     @property
     def locale(self):
         """Locale to use for rendering."""
+        if 'locale' in self.route_info.meta:
+            return self.route_info.meta['locale']
         return self.doc.locale if self.doc else None
 
     @property
     def mimetype(self):
         """Determine headers to serve for https requests."""
         return mimetypes.guess_type(self.doc.view)[0]
+
+    @property
+    def pod_path(self):
+        """Locale to use for rendering."""
+        if 'locale' in self.route_info.meta:
+            return self.route_info.meta['locale']
+        return self.doc.locale if self.doc else None
 
     @property
     def suffix(self):
@@ -147,10 +156,10 @@ class RenderDocumentController(RenderController):
         """Load the pod content from file system."""
         timer = self.pod.profile.timer(
             'RenderDocumentController.load',
-            label='{} ({})'.format(self.doc.pod_path, self.doc.locale),
+            label='{} ({})'.format(self.pod_path, self.locale),
             meta={
-                'path': self.doc.pod_path,
-                'locale': str(self.doc.locale)}
+                'path': self.pod_path,
+                'locale': str(self.locale)}
         ).start_timer()
 
         source_dir = self.clean_source_dir(source_dir)
@@ -160,7 +169,7 @@ class RenderDocumentController(RenderController):
 
         try:
             doc = self.doc
-            serving_path = doc.get_serving_path()
+            serving_path = self.serving_path
             if serving_path.endswith('/'):
                 serving_path = '{}{}'.format(serving_path, self.suffix)
 


### PR DESCRIPTION
Previously, even though all the information was available from the routes file and the `work_dir` contents, the render controller was still accessing doc information which caused the docs to be read from the filesystem and parsed, slowing down the process when it didn't need to access them.