### PR TITLE
Allow the command to complete normally, even when keyboard interrupting.

### DIFF
--- a/grow/commands/subcommands/run.py
+++ b/grow/commands/subcommands/run.py
@@ -54,4 +54,7 @@ def run(host, port, https, debug, browser, update_check, preprocess, ui,
                       update_check=update_check)
     except pods.Error as e:
         raise click.ClickException(str(e))
+    except KeyboardInterrupt:
+        print 'Keyboard!'
+        pass  # Let the normal process work when doing keyboard inturrupt.
     return pod

--- a/grow/server/manager.py
+++ b/grow/server/manager.py
@@ -96,10 +96,7 @@ def start(pod, host=None, port=None, open_browser=False, debug=False,
                 # Clean up the file watchers.
                 main_observer.stop()
                 podspec_observer.stop()
-
-                # Ensure ctrl+c works no matter what.
-                # https://github.com/grow/grow/issues/149
-                os._exit(0)
+                return
 
     text = 'Unable to find a port for the server (tried {}).'
     pod.logger.error(text.format(port))


### PR DESCRIPTION
This allows for the profiler to correctly compile at the end when in use.