### PR TITLE
Fixing the fingerprint stripping to work without the `.min`.

### DIFF
--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -8,7 +8,7 @@ from grow.routing import path_filter as grow_path_filter
 
 # SHA 256 hash length: 64 characters.
 FINGERPRINT_RE = re.compile(
-    r'(.*)(-[a-f0-9]{64})(\.min)?([\.][a-z0-9]{1,5})$', re.IGNORECASE)
+    r'(.*)(-[a-f0-9]{64})((\.min|)[\.][a-z0-9]{1,5})$', re.IGNORECASE)
 
 
 class Error(Exception):
@@ -57,7 +57,7 @@ class StaticDocument(object):
     @staticmethod
     def strip_fingerprint(serving_path):
         """Strip the fingerprint off a serving path."""
-        return FINGERPRINT_RE.sub(r'\1\3\4', serving_path)
+        return FINGERPRINT_RE.sub(r'\1\3', serving_path)
 
     @property
     def base_path_format(self):


### PR DESCRIPTION
Made the `.min` an optional part of the extension and fixed up the regex groups.

Fixes #1007