### PR TITLE
fix: correct wrong value of collection.sub_path

### DIFF
--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -138,7 +138,7 @@ class PathFormat(object):
             params['base'] = doc.base
         params['collection'] = structures.AttributeDict(
             base_path=doc.collection_base_path,
-            sub_path=doc.collection_base_path,
+            sub_path=doc.collection_sub_path,
             basename=doc.collection.basename,
             root=doc.collection.root)
         if '{category}' in path:


### PR DESCRIPTION
This fixes the wrong value of `{collection.sub_path}` used in path formatters.
I could not understand why tests were passing before, sorry, I haven't clearly understood what is tested and how.