### PR TITLE
Fix: Dockerfile pip command line to install grow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV NVM_DIR=~/.nvm
 
 # Install Grow.
 RUN pip3 install --no-cache-dir --upgrade wheel \
-  && pip3 install --no-cache-dir $grow_version
+  && pip3 install --no-cache-dir grow==$grow_version
 
 # Install ruby bundle.
 RUN gem install bundler


### PR DESCRIPTION
This fixes the pip command line that installs Grow.

Test it with `docker build . --build-arg grow_version=2.2.2`