### PR TITLE
fix: Removed useless inheritance from object superseded in Python 3

### DIFF
--- a/grow/cache/collection_cache.py
+++ b/grow/cache/collection_cache.py
@@ -8,7 +8,7 @@ import threading
 from grow.collections import collection
 
 
-class CollectionCache(object):
+class CollectionCache:
 
     def __init__(self):
         self.reset()

--- a/grow/cache/document_cache.py
+++ b/grow/cache/document_cache.py
@@ -7,7 +7,7 @@ The contents of the cache should be raw and not internationalized as it will
 be shared between locales with the same pod_path.
 """
 
-class DocumentCache(object):
+class DocumentCache:
 
     def __init__(self):
         self.reset()

--- a/grow/cache/file_cache.py
+++ b/grow/cache/file_cache.py
@@ -4,7 +4,7 @@ Cache for storing and retrieving file content at a pod_path.
 The contents of the cache can be parsed and are stored based on locale.
 """
 
-class FileCache(object):
+class FileCache:
     """Simple cache for file contents."""
 
     def __init__(self):

--- a/grow/cache/object_cache.py
+++ b/grow/cache/object_cache.py
@@ -14,7 +14,7 @@ FILE_OBJECT_CACHE = 'objectcache.json'
 FILE_OBJECT_SUB_CACHE = 'objectcache.{}.json'
 
 
-class ObjectCache(object):
+class ObjectCache:
     """Object cache for caching arbitrary data in a pod."""
 
     def __contains__(self, key):

--- a/grow/cache/podcache.py
+++ b/grow/cache/podcache.py
@@ -29,7 +29,7 @@ class PodCacheParseError(Error):
     pass
 
 
-class PodCache(object):
+class PodCache:
     """Caching container for the pod."""
 
     KEY_GLOBAL = '__global__'

--- a/grow/cache/routes_cache.py
+++ b/grow/cache/routes_cache.py
@@ -8,7 +8,7 @@ from grow.routing import router
 FILE_ROUTES_CACHE = 'routescache.json'
 
 
-class RoutesCache(object):
+class RoutesCache:
     """Routes cache for caching routing data in a pod."""
 
     KEY_CONCRETE = 'concrete'

--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -48,7 +48,7 @@ class NoLocalesError(Error):
     pass
 
 
-class Collection(object):
+class Collection:
     CONTENT_PATH = '/content'
     BLUEPRINT_PATH = '_blueprint.yaml'
     FEATURE_SEPARATE_ROUTING = 'separate_routing'

--- a/grow/collections/collection_routes.py
+++ b/grow/collections/collection_routes.py
@@ -3,7 +3,7 @@
 import os
 
 
-class CollectionRoutes(object):
+class CollectionRoutes:
     """Collection level routing information."""
 
     ROUTES_PATH = '_routes.yaml'

--- a/grow/commands/deprecated.py
+++ b/grow/commands/deprecated.py
@@ -6,7 +6,7 @@ from click.utils import make_str
 
 
 # pylint: disable=too-few-public-methods
-class DeprecatedItem(object):
+class DeprecatedItem:
     """Configuration for an alias item."""
 
     def __init__(self, old_name, new_name, cmd=None):

--- a/grow/common/base_config.py
+++ b/grow/common/base_config.py
@@ -1,7 +1,7 @@
 """Base Config control class."""
 
 
-class BaseConfig(object):
+class BaseConfig:
     """Base class for identifier based configuration management."""
 
     def __init__(self, config=None):
@@ -41,7 +41,7 @@ class BaseConfig(object):
         item[key] = value
 
 
-class BaseConfigPrefixed(object):
+class BaseConfigPrefixed:
     """Utility class for shortcutting common prefixes in identifiers."""
 
     def __init__(self, config, prefix):

--- a/grow/common/deprecated.py
+++ b/grow/common/deprecated.py
@@ -3,7 +3,7 @@
 import logging
 
 # pylint: disable=too-few-public-methods
-class DeprecationHelper(object):
+class DeprecationHelper:
     """Deprecation helper class for deprecating a class."""
 
     def __init__(self, new_target, message, warn=logging.warn):
@@ -27,7 +27,7 @@ class DeprecationHelper(object):
         return getattr(self.new_target, attr)
 
 # pylint: disable=too-few-public-methods
-class DeprecationManager(object):
+class DeprecationManager:
     """Deprecation manager class for deprecation messages without repeating."""
 
     def __init__(self, warn=logging.warn):

--- a/grow/common/features.py
+++ b/grow/common/features.py
@@ -2,7 +2,7 @@
 
 from grow.common import base_config
 
-class Features(object):
+class Features:
     """Control features."""
 
     def __call__(self, feature):

--- a/grow/common/patched_site.py
+++ b/grow/common/patched_site.py
@@ -348,7 +348,7 @@ def setquit():
     else:
         eof = 'Ctrl-D (i.e. EOF)'
 
-    class Quitter(object):
+    class Quitter:
         def __init__(self, name):
             self.name = name
         def __repr__(self):
@@ -365,7 +365,7 @@ def setquit():
     builtins.exit = Quitter('exit')
 
 
-class _Printer(object):
+class _Printer:
     """interactive prompt objects for printing the license text, a list of
     contributors and the copyright notice."""
 
@@ -444,7 +444,7 @@ def setcopyright():
         [os.path.join(here, os.pardir), here, os.curdir])
 
 
-class _Helper(object):
+class _Helper:
     """Define the builtin 'help'.
     This is a wrapper around pydoc.help (with a twist).
 

--- a/grow/common/progressbar_non.py
+++ b/grow/common/progressbar_non.py
@@ -6,7 +6,7 @@ import datetime
 import progressbar
 
 
-class NonInteractiveProgressBar(object):
+class NonInteractiveProgressBar:
     """Non-interactive stub version of progress bar."""
 
     def __init__(self, message, max_value=None, poll_interval=5, widgets=None, *_args, **kwargs):

--- a/grow/common/structures.py
+++ b/grow/common/structures.py
@@ -41,7 +41,7 @@ class SafeDict(dict):
         return '{' + key + '}'
 
 
-class SortedCollection(object):
+class SortedCollection:
     """Sequence sorted by a key function.
 
     SortedCollection() is much easier to work with than using bisect() directly.

--- a/grow/common/timer.py
+++ b/grow/common/timer.py
@@ -5,7 +5,7 @@ Based off https://www.huyng.com/posts/python-performance-analysis
 
 import time
 
-class Timer(object):
+class Timer:
     def __init__(self, verbose=False):
         self.verbose = verbose
 

--- a/grow/common/untag.py
+++ b/grow/common/untag.py
@@ -7,7 +7,7 @@ from boltons import iterutils
 LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)$')
 
 
-class Untag(object):
+class Untag:
     """Untagging utility for locale and environment based untagging."""
 
     @staticmethod
@@ -115,14 +115,14 @@ class Untag(object):
         return iterutils.remap(data, visit=_visit, exit=_remap_exit)
 
 
-class UntagParam(object):
+class UntagParam:
     """Untagging param for complex untagging."""
 
     def __call__(self, data, untagged_key, param_key, param_value, value, locale_identifier=None):
         raise NotImplementedError()
 
 
-class UntagParamRegex(object):
+class UntagParamRegex:
     """Param using the value of the param value as a regex to match."""
 
     def __init__(self, value):
@@ -137,7 +137,7 @@ class UntagParamRegex(object):
         return untagged_key, value
 
 
-class UntagParamLocaleRegex(object):
+class UntagParamLocaleRegex:
     """Param using a document field as a regex group to match locale.
 
     Attempts to use the value of one of the other data fields as a locale regex.

--- a/grow/common/urls.py
+++ b/grow/common/urls.py
@@ -3,7 +3,7 @@
 import os
 
 
-class Url(object):
+class Url:
     """Url utility class."""
 
     def __init__(self, path, host=None, port=None, scheme=None):

--- a/grow/common/utils.py
+++ b/grow/common/utils.py
@@ -129,7 +129,7 @@ def validate_name(name):
             'backslashes, and dashes. Found: "{}"'.format(name))
 
 
-class memoize(object):
+class memoize:
 
     def __init__(self, func):
         self.func = func
@@ -164,7 +164,7 @@ class cached_property(property):
     and then that calculated result is used the next time you access
     the value::
 
-        class Foo(object):
+        class Foo:
             @cached_property
             def foo(self):
                 # calculate something important here
@@ -519,7 +519,7 @@ def slugify(text, delim='-'):
     return slug
 
 
-class DummyDict(object):
+class DummyDict:
 
     def __getattr__(self, name):
         return ''

--- a/grow/conversion/collection_routing.py
+++ b/grow/conversion/collection_routing.py
@@ -33,7 +33,7 @@ class Error(Exception):
         self.message = message
 
 
-class RoutesData(object):
+class RoutesData:
     """Store and format the routes information pulled from the documents."""
 
     def __init__(self, collection_path, blueprint):
@@ -109,7 +109,7 @@ class RoutesData(object):
             print('')
 
 
-class ConversionCollection(object):
+class ConversionCollection:
     """Temporary collection class for doing a conversion for a collection."""
 
     def __init__(self, pod, collection):
@@ -129,7 +129,7 @@ class ConversionCollection(object):
         self.routes_data.write_routes(self.pod, self.collection)
 
 
-class Converter(object):
+class Converter:
 
     @staticmethod
     def convert(pod):

--- a/grow/conversion/content_locale_split.py
+++ b/grow/conversion/content_locale_split.py
@@ -60,7 +60,7 @@ def _update_deep(orig_dict, new_dict):
             orig_dict[k] = new_dict[k]
 
 
-class PlainText(object):
+class PlainText:
 
     def __init__(self, tag, value):
         self.tag = tag
@@ -110,7 +110,7 @@ PlainTextYamlLoader.add_constructor(
     '!g.yaml', PlainTextYamlLoader.construct_plaintext)
 
 
-class ConversionDocument(object):
+class ConversionDocument:
 
     def __init__(self, pod, file_name, default_locale):
         self.default_locale = default_locale
@@ -407,7 +407,7 @@ class ConversionDocument(object):
                 yield front_matter, content
 
 
-class Converter(object):
+class Converter:
 
     @staticmethod
     def convert(pod):

--- a/grow/deployments/destinations/base.py
+++ b/grow/deployments/destinations/base.py
@@ -98,7 +98,7 @@ class CommandError(Error):
     pass
 
 
-class DestinationTestCase(object):
+class DestinationTestCase:
 
     def __init__(self, deployment):
         self.deployment = deployment
@@ -120,7 +120,7 @@ class DestinationTestCase(object):
                 yield func
 
 
-class BaseDestination(object):
+class BaseDestination:
     """Base destination for building and deploying."""
 
     TestCase = DestinationTestCase

--- a/grow/deployments/indexes.py
+++ b/grow/deployments/indexes.py
@@ -44,7 +44,7 @@ class DeploymentErrors(Error):
         self.errors = errors
 
 
-class Diff(object):
+class Diff:
     POOL_SIZE = 10  # Thread pool size for applying a diff.
     GIT_LOG_MAX = 25
 
@@ -368,7 +368,7 @@ class Diff(object):
         return diff, index, paths_to_rendered_doc
 
 
-class Index(object):
+class Index:
 
     @classmethod
     def create(cls, paths_to_rendered_doc=None):

--- a/grow/deployments/stats.py
+++ b/grow/deployments/stats.py
@@ -7,7 +7,7 @@ from protorpc import protojson
 from . import messages
 
 
-class Stats(object):
+class Stats:
 
     def __init__(self, pod, paths=None, full=True):
         self.full = full

--- a/grow/documents/document.py
+++ b/grow/documents/document.py
@@ -52,7 +52,7 @@ class PathFormatError(Error, ValueError):
     pass
 
 
-class Document(object):
+class Document:
     """Grow content document."""
 
     def __eq__(self, other):

--- a/grow/documents/document_fields.py
+++ b/grow/documents/document_fields.py
@@ -7,7 +7,7 @@ from grow.common import untag
 LOCALIZED_KEY_REGEX = re.compile(r'(.*)@([^@]+)$')
 
 
-class DocumentFields(object):
+class DocumentFields:
 
     def __contains__(self, item):
         return item in self._data

--- a/grow/documents/document_format.py
+++ b/grow/documents/document_format.py
@@ -28,7 +28,7 @@ class BadLocalesError(BadFormatError):
     pass
 
 
-class DocumentFormat(object):
+class DocumentFormat:
     """
     Document formatting specifics for parsing and working with documents.
 

--- a/grow/documents/document_front_matter.py
+++ b/grow/documents/document_front_matter.py
@@ -36,7 +36,7 @@ class BadFormatError(Error, ValueError):
     pass
 
 
-class DocumentFrontMatter(object):
+class DocumentFrontMatter:
     """Document front matter."""
 
     def __init__(self, doc, raw_front_matter=None):

--- a/grow/documents/static_document.py
+++ b/grow/documents/static_document.py
@@ -11,7 +11,7 @@ FINGERPRINT_RE = re.compile(
     r'(.*)(-[a-f0-9]{64})((\.min|)[\.][a-z0-9]{1,5})$', re.IGNORECASE)
 
 
-class StaticDocument(object):
+class StaticDocument:
     """Static document."""
 
     def __eq__(self, other):

--- a/grow/extensions/base_extension.py
+++ b/grow/extensions/base_extension.py
@@ -16,7 +16,7 @@ class MissingHookError(Error):
     pass
 
 
-class BaseExtension(object):
+class BaseExtension:
     """Base extension for custom extensions."""
 
     def __init__(self, pod, config):

--- a/grow/extensions/extension_controller.py
+++ b/grow/extensions/extension_controller.py
@@ -5,7 +5,7 @@ from grow.extensions import extension_importer
 from grow.extensions import hooks
 from grow.extensions import hook_controller
 
-class ExtensionController(object):
+class ExtensionController:
     """Controller for working with pod extensions."""
 
     def __init__(self, pod):

--- a/grow/extensions/hook_controller.py
+++ b/grow/extensions/hook_controller.py
@@ -1,7 +1,7 @@
 """Hook controller for working with hooks from the extensions."""
 
 
-class HookController(object):
+class HookController:
     """Controller for working with pod extension hooks."""
 
     def __init__(self, pod, key, default_hook):

--- a/grow/extensions/hooks/base_hook.py
+++ b/grow/extensions/hooks/base_hook.py
@@ -1,7 +1,7 @@
 """Base class for writing hooks."""
 
 
-class BaseHook(object):
+class BaseHook:
     """Base class for all hooks."""
 
     KEY = 'hook'

--- a/grow/partials/partial.py
+++ b/grow/partials/partial.py
@@ -8,7 +8,7 @@ from grow.common import utils
 split_front_matter = document_front_matter.DocumentFrontMatter.split_front_matter
 
 
-class Partial(object):
+class Partial:
     """Partial from the partial directory."""
 
     def __init__(self, pod_path, pod):
@@ -44,7 +44,7 @@ class Partial(object):
         return os.path.join(self.pod_path, '{}.html'.format(self.key))
 
 
-class ViewPartial(object):
+class ViewPartial:
     """Partial from the views directory."""
 
     def __init__(self, pod_path, pod):

--- a/grow/partials/partials.py
+++ b/grow/partials/partials.py
@@ -4,7 +4,7 @@ import os
 from grow.partials import partial as grow_partial
 
 
-class Partials(object):
+class Partials:
     """Manage partials within the pod."""
 
     PARTIALS_PATH = '/partials'

--- a/grow/performance/docs_loader.py
+++ b/grow/performance/docs_loader.py
@@ -25,7 +25,7 @@ class LoadError(Error):
 
 
 # pylint: disable=too-few-public-methods
-class DocsLoader(object):
+class DocsLoader:
     """Loader that threads the docs' file system reads."""
 
     MAX_POOL_SIZE = 100
@@ -160,7 +160,7 @@ class DocsLoader(object):
         cls.load(pod, _doc_from_routes(routes), **kwargs)
 
 
-class LoadResult(object):
+class LoadResult:
     """Results from a doc loading."""
 
     def __init__(self):

--- a/grow/performance/profile.py
+++ b/grow/performance/profile.py
@@ -3,7 +3,7 @@
 import time
 
 
-class Timer(object):
+class Timer:
     """Times code to see how long it takes using a context manager."""
 
     def __init__(self, key, label=None, meta=None):
@@ -51,7 +51,7 @@ class Timer(object):
         return self
 
 
-class Profile(object):
+class Profile:
     """Keeps track of all of the timer usage."""
 
     def __init__(self):

--- a/grow/performance/profile_report.py
+++ b/grow/performance/profile_report.py
@@ -1,7 +1,7 @@
 """Profiling report for analyizing the performance of the app"""
 
 
-class ProfileReport(object):
+class ProfileReport:
     """Analyzes the timers to report on the app timing."""
 
     def __init__(self, profile):
@@ -34,7 +34,7 @@ class ProfileReport(object):
                     print(timer)
 
 
-class ReportItem(object):
+class ReportItem:
     """Report item used to store information about all timers with the same key."""
 
     def __init__(self, key):

--- a/grow/pods/dependency.py
+++ b/grow/pods/dependency.py
@@ -5,7 +5,7 @@ import os
 from collections import OrderedDict
 
 
-class DependencyGraph(object):
+class DependencyGraph:
     """Dependency graph for tracking relationships between the pod content."""
 
     def __init__(self):

--- a/grow/pods/env.py
+++ b/grow/pods/env.py
@@ -5,7 +5,7 @@ from protorpc import messages
 from grow.common import urls
 
 
-class Name(object):
+class Name:
     DEV = 'dev'
 
 
@@ -19,7 +19,7 @@ class EnvConfig(messages.Message):
     dev = messages.BooleanField(7, default=False)
 
 
-class Env(object):
+class Env:
 
     def __init__(self, config):
         self.name = config.name

--- a/grow/pods/footnotes.py
+++ b/grow/pods/footnotes.py
@@ -76,7 +76,7 @@ def numberic_generator():
         index += 1
 
 
-class Footnotes(object):
+class Footnotes:
     def __init__(self, locale, symbols=None, use_numeric=None,
             use_numeric_symbols=None, numeric_locales_pattern=None):
         self.symbol_to_footnote = collections.OrderedDict()

--- a/grow/pods/pods.py
+++ b/grow/pods/pods.py
@@ -78,7 +78,7 @@ def goodbye_pods():
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
-class Pod(object):
+class Pod:
     """Grow pod."""
     INSTALLED_EXTENSIONS_DIR_PATH = 'extensions'
     LOCAL_EXTENSIONS_DIR_PATH = 'ext'

--- a/grow/pods/podspec.py
+++ b/grow/pods/podspec.py
@@ -14,7 +14,7 @@ class PodSpecParseError(Error):
     pass
 
 
-class PodSpec(object):
+class PodSpec:
 
     def __init__(self, yaml, pod):
         yaml = yaml or {}

--- a/grow/preprocessors/base.py
+++ b/grow/preprocessors/base.py
@@ -12,7 +12,7 @@ class PreprocessorError(Error):
     pass
 
 
-class BasePreprocessor(object):
+class BasePreprocessor:
 
     def __init__(self, pod, config, autorun=True, name=None, tags=[],
                  inject=False):

--- a/grow/rendering/markdown_utils.py
+++ b/grow/rendering/markdown_utils.py
@@ -8,7 +8,7 @@ from grow.common import structures
 from grow.common import utils
 
 
-class MarkdownUtil(object):
+class MarkdownUtil:
     """Utility class for working with pod flavored markdown."""
 
     def __init__(self, pod):

--- a/grow/rendering/render_batch.py
+++ b/grow/rendering/render_batch.py
@@ -72,7 +72,7 @@ def render_func(batch, tick=None):
     return result
 
 
-class RenderBatches(object):
+class RenderBatches:
     """Handles the batching of rendering."""
 
     def __init__(self, render_pool, profile, tick=None, batch_size=None):
@@ -147,7 +147,7 @@ class RenderBatches(object):
         return rendered_docs, render_errors
 
 
-class RenderLocaleBatch(object):
+class RenderLocaleBatch:
     """Handles the rendering and threading of the controllers."""
 
     BATCH_DEFAULT_SIZE = 300  # Default number of documents in a batch.
@@ -277,7 +277,7 @@ class RenderLocaleBatch(object):
         return rendered_docs, render_errors
 
 
-class LoadBatchResult(object):
+class LoadBatchResult:
     """Results from a batched loading."""
 
     def __init__(self):
@@ -285,7 +285,7 @@ class LoadBatchResult(object):
         self.loaded_docs = []
 
 
-class RenderBatchResult(object):
+class RenderBatchResult:
     """Results from a batched rendering."""
 
     def __init__(self):

--- a/grow/rendering/render_controller.py
+++ b/grow/rendering/render_controller.py
@@ -31,7 +31,7 @@ class IgnoredPathError(Error):
     pass
 
 
-class RenderController(object):
+class RenderController:
     """Controls how the content is rendered and evaluated."""
 
     def __init__(self, pod, serving_path, route_info, params=None, is_threaded=False):

--- a/grow/rendering/render_pool.py
+++ b/grow/rendering/render_pool.py
@@ -16,7 +16,7 @@ class Error(Exception):
         self.message = message
 
 
-class RenderPool(object):
+class RenderPool:
     """Rendering pool for rendering pods."""
 
     def __init__(self, pod, pool_size=1):

--- a/grow/rendering/rendered_document.py
+++ b/grow/rendering/rendered_document.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 
 
-class RenderedDocument(object):
+class RenderedDocument:
     """Keeps track of the information for the rendered document."""
 
     def __init__(self, path, content=None, tmp_dir=None):

--- a/grow/rendering/renderer.py
+++ b/grow/rendering/renderer.py
@@ -6,7 +6,7 @@ from grow.common import bulk_errors
 from grow.rendering import render_batch
 
 
-class Renderer(object):
+class Renderer:
     """Handles the rendering and threading of the controllers."""
 
     @staticmethod

--- a/grow/routing/path_filter.py
+++ b/grow/routing/path_filter.py
@@ -9,7 +9,7 @@ DEFAULT_IGNORED = [
 DEFAULT_INCLUDED = []
 
 
-class PathFilter(object):
+class PathFilter:
     """Filter for testing paths against a set of filter criteria."""
 
     def __init__(self, ignored=None, included=None):

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -12,7 +12,7 @@ VALID_DOC_EXTENSIONS = ('.html', '.htm', '.xml', '.svg')
 INDEX_BASE_ENDINGS = ('/{base}', '/{base}/')
 
 
-class PathFormat(object):
+class PathFormat:
     """Format url paths using the information from the pod."""
 
     PARAM_CURLY_REGEX_SECTION = re.compile(r'/{([^}]*)}/')

--- a/grow/routing/router.py
+++ b/grow/routing/router.py
@@ -32,7 +32,7 @@ class MissingStaticConfigError(Error):
     pass
 
 
-class Router(object):
+class Router:
     """Router for pods."""
 
     def __init__(self, pod, routes=None):
@@ -573,7 +573,7 @@ class Router(object):
 
 
 # pylint: disable=too-few-public-methods
-class RouteInfo(object):
+class RouteInfo:
     """Organize information stored in the routes."""
 
     def __eq__(self, other):

--- a/grow/routing/routes.py
+++ b/grow/routing/routes.py
@@ -51,7 +51,7 @@ class PathParamNameConflictError(Error):
         self.existing_param = existing_param
 
 
-class Routes(object):
+class Routes:
     """Routes container for mapping paths to documents."""
 
     def __add__(self, other):
@@ -154,7 +154,7 @@ class RoutesSimple(Routes):
         self._root = RoutesDict()
 
 
-class RoutesDict(object):
+class RoutesDict:
     """Dictionary based routing tree for faster creation."""
 
     def __init__(self):
@@ -231,7 +231,7 @@ class RoutesDict(object):
             self._root.pop(path, None)
 
 
-class RouteTrie(object):
+class RouteTrie:
     """A trie for routes."""
 
     def __init__(self):
@@ -291,7 +291,7 @@ class RouteTrie(object):
         raise NotImplementedError('Sharding cannot be done on routing trie.')
 
 
-class RouteNode(object):
+class RouteNode:
     """Individual node in the routes trie."""
 
     def __init__(self, param_name=None):
@@ -556,7 +556,7 @@ class RouteWildcardNode(RouteNode):
 
 
 # pylint: disable=too-few-public-methods
-class MatchResult(object):
+class MatchResult:
     """Node information for a trie match."""
 
     def __init__(self, path, value, params=None):

--- a/grow/routing/routes_test.py
+++ b/grow/routing/routes_test.py
@@ -816,7 +816,7 @@ class RoutesSimpleTestCase(unittest.TestCase):
 
 
         # pylint: disable=too-few-public-methods
-        class _RouteInfo(object):
+        class _RouteInfo:
             """Organize information stored in the routes."""
 
             def __init__(self, kind):

--- a/grow/sdk/installer.py
+++ b/grow/sdk/installer.py
@@ -17,7 +17,7 @@ class Error(Exception):
         self.message = message
 
 
-class Installer(object):
+class Installer:
     """Grow installer for dependencies."""
 
     def __init__(self, installers, pod):

--- a/grow/sdk/installers/base_installer.py
+++ b/grow/sdk/installers/base_installer.py
@@ -24,7 +24,7 @@ class InstallError(Error):
     pass
 
 
-class BaseInstaller(object):
+class BaseInstaller:
     """Base class for grow installers."""
 
     KIND = None

--- a/grow/server/main.py
+++ b/grow/server/main.py
@@ -23,7 +23,7 @@ class RequestHandler(serving.WSGIRequestHandler):
         pass
 
 
-class PodServer(object):
+class PodServer:
 
     def __call__(self, environ, start_response):
         return self.wsgi_app(environ, start_response)

--- a/grow/storage/base_storage.py
+++ b/grow/storage/base_storage.py
@@ -1,4 +1,4 @@
-class BaseStorage(object):
+class BaseStorage:
 
     is_cloud_storage = False
 

--- a/grow/templates/doc_dependency.py
+++ b/grow/templates/doc_dependency.py
@@ -2,7 +2,7 @@
 
 
 # pylint: disable=too-few-public-methods
-class DocDependency(object):
+class DocDependency:
     """Used to easily track a dependencies for a document."""
 
     def __init__(self, doc):

--- a/grow/templates/tags.py
+++ b/grow/templates/tags.py
@@ -12,7 +12,7 @@ from grow.pods import errors
 from grow.translations import locales as locales_lib
 
 
-class Menu(object):
+class Menu:
     """Helper class for creating navigation menus."""
 
     def __init__(self):

--- a/grow/testing/google_service.py
+++ b/grow/testing/google_service.py
@@ -3,7 +3,7 @@
 import mock
 
 
-class GoogleServiceMock(object):
+class GoogleServiceMock:
     """Utility for creating mocks for Google APIs."""
 
     @classmethod

--- a/grow/translations/catalog_holder.py
+++ b/grow/translations/catalog_holder.py
@@ -42,7 +42,7 @@ class UsageError(Error, click.UsageError):
     pass
 
 
-class Catalogs(object):
+class Catalogs:
     root = '/translations'
 
     def __init__(self, pod, template_path=None):

--- a/grow/translations/catalogs_test.py
+++ b/grow/translations/catalogs_test.py
@@ -64,7 +64,7 @@ class CatalogTest(unittest.TestCase):
         self.assertEqual(14, len(untranslated))
 
     def test__message_in_paths(self):
-        class DummyMessage(object):
+        class DummyMessage:
             def __init__(self, locations):
                 self.locations = [(location, 0) for location in locations]
         message = DummyMessage([

--- a/grow/translations/importers.py
+++ b/grow/translations/importers.py
@@ -47,7 +47,7 @@ class Error(Exception):
         self.message = message
 
 
-class Importer(object):
+class Importer:
 
     def __init__(self, pod, include_obsolete=True, untranslated=False):
         self.pod = pod

--- a/grow/translations/locales.py
+++ b/grow/translations/locales.py
@@ -7,7 +7,7 @@ import babel
 import re
 
 
-class Locales(object):
+class Locales:
 
     def __init__(self, pod):
         self.pod = pod

--- a/grow/translations/translation_stats.py
+++ b/grow/translations/translation_stats.py
@@ -7,7 +7,7 @@ import traceback
 import texttable
 
 
-class TranslationStats(object):
+class TranslationStats:
 
     ROW_COUNT = 7
 

--- a/grow/translators/base.py
+++ b/grow/translators/base.py
@@ -52,7 +52,7 @@ class TranslatorServiceError(Exception):
         super(TranslatorServiceError, self).__init__(new_message)
 
 
-class Translator(object):
+class Translator:
     TRANSLATOR_STATS_PATH = '/translators.yaml'
     KIND = None
     has_immutable_translation_resources = False

--- a/grow/translators/google_sheets.py
+++ b/grow/translators/google_sheets.py
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover
 from . import base
 
 
-class AccessLevel(object):
+class AccessLevel:
     COMMENTER = 'commenter'
     OWNER = 'owner'
     READER = 'reader'

--- a/grow/translators/google_translator_toolkit.py
+++ b/grow/translators/google_translator_toolkit.py
@@ -17,14 +17,14 @@ OAUTH_SCOPE = 'https://www.googleapis.com/auth/gte'
 STORAGE_KEY = 'Grow SDK - Google Translator Toolkit'
 
 
-class AccessLevel(object):
+class AccessLevel:
     ADMIN = 'ADMIN'
     READ_AND_COMMENT = 'READ_AND_COMMENT'
     READ_AND_WRITE = 'READ_AND_WRITE'
     READ_ONLY = 'READ_ONLY'
 
 
-class ChangeType(object):
+class ChangeType:
     MODIFY = 'MODIFY'
     ADD = 'ADD'
 
@@ -36,7 +36,7 @@ def raise_service_error(http_error, locale=None, ident=None):
     raise base.TranslatorServiceError(message=message, locale=locale, ident=ident)
 
 
-class Gtt(object):
+class Gtt:
 
     def __init__(self):
         self.service = discovery.build('gte', 'v1', http=self.http)


### PR DESCRIPTION
Given Python 2 is long gone I think we can get rid of the explicit inheritance from `object` in all Grow classes, unless there is a reason to keep it. In that case, sorry for the giant PR :joy_cat:  (it took me 5 seconds with `sed`, actually).