### PR TITLE
feat: add collection path and dirname

### DIFF
--- a/grow/collections/collection.py
+++ b/grow/collections/collection.py
@@ -74,6 +74,7 @@ class Collection:
         self.pod = _pod
         self.pod_path = pod_path
         self.collection_path = Collection.clean_collection_path(pod_path)
+        self.dirname = os.path.dirname(self.collection_path)
         self.basename = os.path.basename(self.collection_path)
         self.blueprint_path = os.path.join(
             self.pod_path, Collection.BLUEPRINT_PATH)

--- a/grow/routing/path_format.py
+++ b/grow/routing/path_format.py
@@ -139,6 +139,8 @@ class PathFormat:
         params['collection'] = structures.AttributeDict(
             base_path=doc.collection_base_path,
             sub_path=doc.collection_sub_path,
+            path=doc.collection.collection_path,
+            dirname=doc.collection.dirname,
             basename=doc.collection.basename,
             root=doc.collection.root)
         if '{category}' in path:


### PR DESCRIPTION
This adds the attribute `dirname` to the class `Collection`. That is the mirror of `basename` in `collection_path`.
This also adds `collection.path` and `collection.dirname` to the path formatter, to allow using those values in URLs.

This addresses some of the issues explained at https://github.com/lgiordani/grow-test-site. That repository now contains updates that showcase the fix in action.