### PR TITLE
fix: add instructions for using standard virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nosetests.xml
 .project
 .pydevproject
 .vscode
+
+# Requirements file
+requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,38 @@ make develop-linux
 make test
 ```
 
+## Development without pipenv
+
+If you are using standard virtual environments or a different virtual environment manager (like pyenv) you can follow this instructions.
+
+### Install libyaml
+
+```bash
+# On Mac with Homebrew (https://brew.sh/).
+brew install libyaml
+
+# On Ubuntu.
+sudo apt install libyaml-dev
+```
+
+### Create the virtualenv and activate it
+
+Follow the instructions of your virtual environment manager.
+
+### Create requirements
+
+You can create the file `requirements.txt` with
+
+```bash
+cat Pipfile | grep '[=<>]=' | sed -e s," = ",, -e s,\",,g > requirements.txt
+```
+
+then install the requirements with
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Commit messages
 
 [Release Please](https://github.com/googleapis/release-please) is used to

--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ pipenv run grow install
 pipenv run grow run
 ```
 
+## Development without pipenv
+
+If you are using standard virtual environments or a different virtual environment manager (like pyenv) you can follwo this instructions.
+
+### Install libyaml
+
+```bash
+# On Mac with Homebrew (https://brew.sh/).
+brew install pipenv libyaml
+
+# On Ubuntu.
+sudo apt install -y pipenv libyaml-dev
+```
+
+### Create the virtualenv and activate it
+
+Follow the instructions of your virtual environment manager.
+
+### Create requirements
+
+You can create the file `requirements.txt` with
+
+```bash
+cat Pipfile | grep '[=<>]=' | sed -e s," = ",, -e s,\",,g > requirements.txt
+```
+
+then install the requirements with
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Documentation
 
 Visit https://grow.dev to read the documentation.

--- a/README.md
+++ b/README.md
@@ -43,36 +43,26 @@ pipenv run grow install
 pipenv run grow run
 ```
 
-## Development without pipenv
+## Install without pipenv
 
-If you are using standard virtual environments or a different virtual environment manager (like pyenv) you can follwo this instructions.
+If you are using standard virtual environments or a different virtual environment manager (like pyenv) you can follow this instructions.
 
-### Install libyaml
+Install `libyaml`
 
 ```bash
 # On Mac with Homebrew (https://brew.sh/).
-brew install pipenv libyaml
+brew install libyaml
 
 # On Ubuntu.
-sudo apt install -y pipenv libyaml-dev
+sudo apt install libyaml-dev
 ```
 
-### Create the virtualenv and activate it
+Follow the instructions of your virtual environment manager to create and activate the virtual environment.
 
-Follow the instructions of your virtual environment manager.
-
-### Create requirements
-
-You can create the file `requirements.txt` with
+Install Grow
 
 ```bash
-cat Pipfile | grep '[=<>]=' | sed -e s," = ",, -e s,\",,g > requirements.txt
-```
-
-then install the requirements with
-
-```bash
-pip install -r requirements.txt
+pip install grow
 ```
 
 ## Documentation


### PR DESCRIPTION
Some developers might prefer to manage virtual environments the traditional way, or to use other virtual environment managers like pyenv (which I use). I think giving instructions on how to set up the development environment in those cases is cheap and doesn't damage the standard setup of the project.