### PR TITLE
fix: add instructions to test using pytest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,20 @@ make develop-linux
 make test
 ```
 
+## Testing with pytest
+
+You can test Grow using [pytest](https://docs.pytest.org/en/latest/) which is compatible with the library `Unittest`. Install pytest and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) with
+
+```bash
+pip install pytest pytest-cov
+```
+
+then run
+
+```bash
+pytest -svv --cov=grow
+```
+
 ## Commit messages
 
 [Release Please](https://github.com/googleapis/release-please) is used to

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ pipenv run grow install
 pipenv run grow run
 ```
 
+## Testing with pytest
+
+You can test Grow using [pytest](https://docs.pytest.org/en/latest/) which is compatible with the library `Unittest`. Install pytest and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) with
+
+```bash
+pip install pytest pytest-cov
+```
+
+then run
+
+``bash
+pytest -svv --cov=grow
+```
+
 ## Documentation
 
 Visit https://grow.dev to read the documentation.

--- a/README.md
+++ b/README.md
@@ -43,20 +43,6 @@ pipenv run grow install
 pipenv run grow run
 ```
 
-## Testing with pytest
-
-You can test Grow using [pytest](https://docs.pytest.org/en/latest/) which is compatible with the library `Unittest`. Install pytest and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) with
-
-```bash
-pip install pytest pytest-cov
-```
-
-then run
-
-``bash
-pytest -svv --cov=grow
-```
-
 ## Documentation
 
 Visit https://grow.dev to read the documentation.


### PR DESCRIPTION
This adds instructions on how to test Grow using pytest. As the framework is compatible with `Unittest` the whole suite works out of the box. For the reasons behind this addition see https://github.com/grow/grow/discussions/1199