### PR TITLE
fix: fix document equality and bugs in next() and prev()

### DIFF
--- a/grow/collections/collection_test.py
+++ b/grow/collections/collection_test.py
@@ -136,7 +136,7 @@ class CollectionsTestCase(unittest.TestCase):
         collection = self.pod.get_collection('empty-front-matter')
         docs = collection.docs()
         path = '/content/empty-front-matter/empty-front-matter.html'
-        expected_doc = self.pod.get_doc(path)
+        expected_doc = self.pod.get_doc(path, locale="it")
         self.assertEqual(expected_doc, docs[0])
 
     def test_fields(self):

--- a/grow/documents/document_test.py
+++ b/grow/documents/document_test.py
@@ -248,6 +248,32 @@ class DocumentsTestCase(unittest.TestCase):
         self.assertEqual(
             expected, document.Document.localize_path(path, locale=locale))
 
+    def test_next_document(self):
+        doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
+        expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
+        next_doc = doc.next()
+        
+        self.assertEqual(next_doc, expected_next_doc)
+        self.assertEqual(next_doc.locale, expected_next_doc.locale)
+        
+    def test_next_document_with_explicit_docs(self):
+        collection = self.pod.get_collection('pages')
+        docs = collection.list_docs()
+
+        doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
+        expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
+        next_doc = doc.next()
+
+        self.assertEqual(next_doc, expected_next_doc)
+        self.assertEqual(next_doc.locale, expected_next_doc.locale)
+
+    def test_next_document_last(self):
+        doc = self.pod.get_doc('/content/pages/contact.yaml', locale="de")
+        expected_next_doc = None
+        next_doc = doc.next()
+        
+        self.assertEqual(next_doc, expected_next_doc)
+
     def test_next_prev(self):
         collection = self.pod.get_collection('pages')
         docs = collection.list_docs()

--- a/grow/documents/document_test.py
+++ b/grow/documents/document_test.py
@@ -22,15 +22,9 @@ class DocumentsTestCase(unittest.TestCase):
         doc2 = self.pod.get_doc('/content/pages/contact.yaml')
         self.assertEqual(doc1, doc2)
 
-        col = self.pod.get_collection('pages')
-        for doc in col:
-            if doc.pod_path == '/content/pages/contact.yaml':
-                self.assertEqual(doc1, doc)
-                self.assertEqual(doc2, doc)
-
         doc1 = self.pod.get_doc('/content/pages/about.yaml')
         doc2 = self.pod.get_doc('/content/pages/about@de.yaml')
-        self.assertEqual(doc1, doc2)
+        self.assertNotEqual(doc1, doc2)
 
     def test_ge(self):
         """Test greater-than-equal comparison."""
@@ -41,7 +35,7 @@ class DocumentsTestCase(unittest.TestCase):
         doc1 = self.pod.get_doc('/content/pages/bravo.yaml', locale='fr')
         doc2 = self.pod.get_doc('/content/pages/bravo.yaml', locale='de')
         self.assertTrue(doc1 >= doc2)
-
+        
         doc1 = self.pod.get_doc('/content/pages/bravo.yaml', locale='fr')
         doc2 = self.pod.get_doc('/content/pages/bravo.yaml', locale='fr')
         self.assertTrue(doc1 >= doc2)
@@ -252,26 +246,48 @@ class DocumentsTestCase(unittest.TestCase):
         doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
         expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
         next_doc = doc.next()
-        
+
         self.assertEqual(next_doc, expected_next_doc)
-        self.assertEqual(next_doc.locale, expected_next_doc.locale)
-        
+
     def test_next_document_with_explicit_docs(self):
         collection = self.pod.get_collection('pages')
         docs = collection.list_docs()
 
         doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
         expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
-        next_doc = doc.next()
+        next_doc = doc.next(docs)
 
         self.assertEqual(next_doc, expected_next_doc)
-        self.assertEqual(next_doc.locale, expected_next_doc.locale)
 
     def test_next_document_last(self):
         doc = self.pod.get_doc('/content/pages/contact.yaml', locale="de")
         expected_next_doc = None
         next_doc = doc.next()
-        
+
+        self.assertEqual(next_doc, expected_next_doc)
+
+    def test_prev_document(self):
+        doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
+        expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
+        next_doc = doc.prev()
+
+        self.assertEqual(next_doc, expected_next_doc)
+
+    def test_prev_document_with_explicit_docs(self):
+        collection = self.pod.get_collection('pages')
+        docs = collection.list_docs()
+
+        doc = self.pod.get_doc('/content/pages/contact.yaml', locale="fr")
+        expected_next_doc = self.pod.get_doc('/content/pages/contact.yaml', locale="it")
+        next_doc = doc.prev(docs)
+
+        self.assertEqual(next_doc, expected_next_doc)
+
+    def test_prev_document_first(self):
+        doc = self.pod.get_doc('/content/pages/home.yaml', locale="it")
+        expected_next_doc = None
+        next_doc = doc.prev()
+
         self.assertEqual(next_doc, expected_next_doc)
 
     def test_next_prev(self):


### PR DESCRIPTION
resolves #1201 

This is an attempt to fix the problem highlighted in #1201 but I'm not sure this is what the Grow developers had in mind originally. 

Also, while this fixes an existing bug in next() and prev(), it also breaks the behaviour of the tool when it comes to document comparison. So, I'm not sure if we should consider it a fix or not, in case it was accepted.